### PR TITLE
docs: add sk installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,16 @@ Write Python code in n8n Code nodes with proper limitations awareness.
 # Select "n8n-mcp-skills" from the list
 ```
 
-**Method 3: Manual Installation**
+**Method 3: Install with sk**
+
+Install via [sk](https://github.com/803/skills-supply), the universal package manager for AI agent skills (supports Claude, Codex, OpenCode, etc...).
+
+```bash
+sk pkg add claude-plugin n8n-mcp-skills@czlonkowski/n8n-skills
+sk sync
+```
+
+**Method 4: Manual Installation**
 ```bash
 # 1. Clone this repository
 git clone https://github.com/czlonkowski/n8n-skills.git

--- a/README.md
+++ b/README.md
@@ -149,11 +149,12 @@ Write Python code in n8n Code nodes with proper limitations awareness.
 # Select "n8n-mcp-skills" from the list
 ```
 
-**Method 3: Install with sk**
+**Method 3: Install with `sk`**
 
-Install via [sk](https://github.com/803/skills-supply), the universal package manager for AI agent skills (supports Claude, Codex, OpenCode, etc...).
+Install n8n-skills via [sk](https://github.com/803/skills-supply) (supports Codex, Amp, OpenCode, Factory, Claude Code etc...).
 
 ```bash
+# Add --global flag if you'd like to install in user-scope (defaults to project-scope)
 sk pkg add claude-plugin n8n-mcp-skills@czlonkowski/n8n-skills
 sk sync
 ```

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -81,11 +81,12 @@ ls ~/.claude/skills/
 
 ---
 
-### Method 2: Install with sk
+### Method 2: Install with `sk`
 
-Install via [sk](https://github.com/803/skills-supply), the universal package manager for AI agent skills (supports Claude, Codex, OpenCode, etc...).
+Install n8n-skills via [sk](https://github.com/803/skills-supply) (supports Codex, Amp, OpenCode, Factory, Claude Code etc...).
 
 ```bash
+# Add --global flag if you'd like to install in user-scope (defaults to project-scope)
 sk pkg add claude-plugin n8n-mcp-skills@czlonkowski/n8n-skills
 sk sync
 ```

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -81,7 +81,18 @@ ls ~/.claude/skills/
 
 ---
 
-### Method 2: Claude.ai (Web Interface)
+### Method 2: Install with sk
+
+Install via [sk](https://github.com/803/skills-supply), the universal package manager for AI agent skills (supports Claude, Codex, OpenCode, etc...).
+
+```bash
+sk pkg add claude-plugin n8n-mcp-skills@czlonkowski/n8n-skills
+sk sync
+```
+
+---
+
+### Method 3: Claude.ai (Web Interface)
 
 **Step 1**: Download skill folders
 
@@ -116,7 +127,7 @@ You should see all 5 n8n skills listed.
 
 ---
 
-### Method 3: Claude API / SDK
+### Method 4: Claude API / SDK
 
 **Step 1**: Install via package manager
 


### PR DESCRIPTION
`sk` is a universal package manager (works across all coding agents), handles updates, etc.. (npm/cargo for agents).

would you be open to adding this?
