### PR TITLE
docs: document alwaysOutputData for database write nodes

### DIFF
--- a/skills/n8n-node-configuration/SKILL.md
+++ b/skills/n8n-node-configuration/SKILL.md
@@ -429,6 +429,11 @@ get_node({
 - operation="insert" → table + values required
 - operation="update" → table + values + where required
 
+**Critical: Write operations return 0 items**
+- INSERT, UPDATE, DELETE produce 0 n8n output items (database returns 0 result rows)
+- Set `alwaysOutputData: true` on write-operation nodes to keep downstream chains alive
+- Downstream nodes should use `$('UpstreamNode').all()` instead of `$input` if they need data
+
 ### Pattern 4: Conditional Logic Nodes
 
 **Examples**: IF, Switch, Merge

--- a/skills/n8n-workflow-patterns/database_operations.md
+++ b/skills/n8n-workflow-patterns/database_operations.md
@@ -705,6 +705,25 @@ SELECT 1000000 records → Process all → OOM error
 SELECT records → Split In Batches (1000) → Process → Loop
 ```
 
+### 5. ❌ Wrong: Expecting output items from write operations
+```
+INSERT INTO table ... → Next node never executes (0 output items)
+```
+
+Database write operations (INSERT, UPDATE, DELETE) return **0 result rows** from the database engine.
+n8n translates this to **0 output items**, silently breaking any downstream chain.
+
+### ✅ Correct: Set `alwaysOutputData` on write nodes
+```
+INSERT INTO table ... (alwaysOutputData: true) → Next node executes with 1 empty item
+```
+
+Set `alwaysOutputData: true` on any node that executes INSERT, UPDATE, or DELETE.
+This ensures at least 1 empty item (`{json: {}}`) flows downstream.
+
+> **Tip:** If downstream nodes need actual data (not the empty passthrough item),
+> reference the upstream node directly: `$('DataSource Node').all()`
+
 ---
 
 ## Real Template Examples


### PR DESCRIPTION
## Summary

Database write operations (INSERT, UPDATE, DELETE) return **0 result rows** from the database engine. n8n translates this to **0 output items**, which silently breaks any downstream node chain — the next node simply never executes.

The fix is setting `alwaysOutputData: true` on write-operation nodes, but this isn't documented anywhere in the skills library. We discovered this the hard way while debugging a production workflow where a BigQuery INSERT node was silently swallowing output.

## Changes

### 1. `database_operations.md` — New Gotcha #5

Added a ❌ Wrong / ✅ Correct gotcha pattern (matching the existing format) that documents:
- Write operations return 0 items
- Set `alwaysOutputData: true` to keep chains alive
- Use `$('UpstreamNode').all()` for downstream data access

### 2. `n8n-node-configuration/SKILL.md` — Pattern 3 expansion

Added a "Critical: Write operations return 0 items" note under Pattern 3 (Database Nodes), since this is a configuration concern that applies to all database write operations.

## Real-world context

We had a sub-workflow chain: `Format Final Output → Log to BQ → Insert Score Log → Return Insights`. The `Insert Score Log` node executed a BigQuery INSERT successfully, but produced 0 output items. The `Return Insights` node never executed, so the sub-workflow returned 0 insight items to its caller — despite the generation succeeding with a score of 83/100.

Setting `alwaysOutputData: true` on the INSERT node fixed it immediately. The downstream `Return Insights` node uses `$('Format Final Output').all()` to reference the actual data, so the empty passthrough item just triggers execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)