### PR TITLE
feat: update skills for n8n-mcp v2.25 new tools and features

### DIFF
--- a/evaluations/mcp-tools/eval-006-search-before-create.json
+++ b/evaluations/mcp-tools/eval-006-search-before-create.json
@@ -1,0 +1,24 @@
+{
+  "id": "mcp-006",
+  "skills": ["n8n-mcp-tools-expert"],
+  "query": "I want to create a new webhook workflow called 'Slack Notifier'. How should I start?",
+  "expected_behavior": [
+    "Recommends searching for existing workflows first with n8n_find_workflow",
+    "Shows n8n_find_workflow({name: 'Slack Notifier'}) before creating",
+    "Explains the three match modes: exact, contains, fuzzy",
+    "Shows the pattern: search → create or update existing",
+    "Mentions the activate parameter for one-call creation+activation",
+    "References the workflow lifecycle in WORKFLOW_GUIDE.md"
+  ],
+  "baseline_without_skill": {
+    "likely_response": "Would jump straight to n8n_create_workflow without checking for duplicates",
+    "expected_quality": "Medium - works but may create duplicate workflows"
+  },
+  "with_skill_expected": {
+    "response_quality": "High - prevents duplicates and follows best practice",
+    "uses_skill_content": true,
+    "searches_before_creating": true,
+    "uses_find_workflow": true,
+    "mentions_activate_parameter": true
+  }
+}

--- a/evaluations/mcp-tools/eval-007-credential-discovery.json
+++ b/evaluations/mcp-tools/eval-007-credential-discovery.json
@@ -1,0 +1,24 @@
+{
+  "id": "mcp-007",
+  "skills": ["n8n-mcp-tools-expert"],
+  "query": "I need to configure a Slack node in my workflow but I don't know the credential ID. How do I find it?",
+  "expected_behavior": [
+    "Recommends n8n_list_credentials to discover credential IDs",
+    "Shows filtering by type: n8n_list_credentials({type: 'slackApi'})",
+    "Shows filtering by name: n8n_list_credentials({name: 'Production'})",
+    "Explains that only metadata is returned, no secrets",
+    "Shows how to use the credential ID in node configuration",
+    "References SEARCH_GUIDE.md for the complete credential discovery workflow"
+  ],
+  "baseline_without_skill": {
+    "likely_response": "Would suggest looking in the n8n UI or guessing credential IDs",
+    "expected_quality": "Low - no programmatic way to discover credentials"
+  },
+  "with_skill_expected": {
+    "response_quality": "High - provides direct API-based credential discovery",
+    "uses_skill_content": true,
+    "uses_list_credentials": true,
+    "shows_type_filter": true,
+    "explains_security": true
+  }
+}

--- a/evaluations/mcp-tools/eval-008-internal-api-operations.json
+++ b/evaluations/mcp-tools/eval-008-internal-api-operations.json
@@ -1,0 +1,25 @@
+{
+  "id": "mcp-008",
+  "skills": ["n8n-mcp-tools-expert"],
+  "query": "I need to debug my workflow by pinning test data to the HTTP Request node, and then test it to verify the output is correct. How do I do this?",
+  "expected_behavior": [
+    "Shows setPinData operation for n8n_update_partial_workflow",
+    "Shows the correct data format: [{json: {...}}]",
+    "Explains the Internal API requirement (N8N_USER_EMAIL + N8N_USER_PASSWORD)",
+    "Shows n8n_test_workflow with expectedOutput and assertionMode",
+    "Shows clearPinData to clean up after testing",
+    "Mentions graceful degradation if Internal API credentials not configured"
+  ],
+  "baseline_without_skill": {
+    "likely_response": "Would suggest manually pinning data in the n8n UI",
+    "expected_quality": "Low - no programmatic approach for pin data or assertions"
+  },
+  "with_skill_expected": {
+    "response_quality": "High - complete test-driven workflow debugging pattern",
+    "uses_skill_content": true,
+    "uses_set_pin_data": true,
+    "uses_test_assertions": true,
+    "mentions_internal_api": true,
+    "shows_cleanup": true
+  }
+}

--- a/evaluations/workflow-patterns/eval-006-search-before-create.json
+++ b/evaluations/workflow-patterns/eval-006-search-before-create.json
@@ -1,0 +1,26 @@
+{
+  "id": "workflow-006",
+  "skills": ["n8n-workflow-patterns"],
+  "query": "I need to build a webhook to database sync workflow. Walk me through the full creation process.",
+  "expected_behavior": [
+    "Starts with searching for existing workflows (n8n_find_workflow)",
+    "Follows the updated workflow creation checklist",
+    "Mentions credential discovery (n8n_list_credentials) for database credentials",
+    "Includes testing with assertions (expectedOutput)",
+    "Mentions pin data for debugging complex transformations",
+    "Uses the activate parameter or activateWorkflow operation",
+    "Follows the webhook processing + database operations patterns"
+  ],
+  "baseline_without_skill": {
+    "likely_response": "Would jump straight to creating the workflow without checking for duplicates or discovering credentials",
+    "expected_quality": "Medium - functional but missing best practices"
+  },
+  "with_skill_expected": {
+    "response_quality": "High - follows complete checklist with new tools",
+    "uses_skill_content": true,
+    "searches_before_creating": true,
+    "discovers_credentials": true,
+    "tests_with_assertions": true,
+    "follows_checklist": true
+  }
+}

--- a/skills/n8n-mcp-tools-expert/README.md
+++ b/skills/n8n-mcp-tools-expert/README.md
@@ -21,7 +21,7 @@ Teaches how to use n8n-mcp MCP server tools correctly for efficient workflow bui
 
 ## File Count
 
-5 files, ~1,150 lines total
+5 files, ~1,500 lines total
 
 ## Priority
 
@@ -29,7 +29,7 @@ Teaches how to use n8n-mcp MCP server tools correctly for efficient workflow bui
 
 ## Dependencies
 
-**n8n-mcp tools**: All of them! (40+ tools)
+**n8n-mcp tools**: All of them! (45+ tools)
 
 **Related skills**:
 - n8n Expression Syntax (write expressions for workflows)
@@ -45,8 +45,11 @@ Teaches how to use n8n-mcp MCP server tools correctly for efficient workflow bui
 - Validation profiles (minimal/runtime/ai-friendly/strict)
 - Smart parameters (branch, case for multi-output nodes)
 - Auto-sanitization system
-- Workflow management (15 operation types)
+- Workflow management (20 operation types)
 - AI connection types (8 types)
+- New tools (n8n_find_workflow, n8n_list_credentials, n8n_sync_installed_nodes)
+- Internal API operations (setPinData, clearPinData, updateDescription)
+- Enhanced tools (get_workflow summary mode, create_workflow activate, test_workflow assertions)
 
 ### Tool Categories
 - Node Discovery (search, list, essentials, info)
@@ -57,12 +60,15 @@ Teaches how to use n8n-mcp MCP server tools correctly for efficient workflow bui
 
 ## Evaluations
 
-5 scenarios (100% coverage expected):
+8 scenarios (100% coverage expected):
 1. **eval-001**: Tool selection (search_nodes)
 2. **eval-002**: nodeType format (nodes-base.* prefix)
 3. **eval-003**: Validation workflow (profiles)
 4. **eval-004**: essentials vs info (5KB vs 100KB)
 5. **eval-005**: Smart parameters (branch, case)
+6. **eval-006**: Search before create (n8n_find_workflow)
+7. **eval-007**: Credential discovery (n8n_list_credentials)
+8. **eval-008**: Internal API operations (setPinData, assertions)
 
 ## Key Features
 
@@ -71,7 +77,7 @@ Teaches how to use n8n-mcp MCP server tools correctly for efficient workflow bui
 ✅ **Format Guidance**: nodeType format differences explained
 ✅ **Smart Parameters**: Semantic branch/case routing for multi-output nodes
 ✅ **Auto-Sanitization**: Explains automatic validation fixes
-✅ **Comprehensive**: Covers all 40+ MCP tools
+✅ **Comprehensive**: Covers all 45+ MCP tools
 
 ## Files
 
@@ -91,7 +97,7 @@ Teaches how to use n8n-mcp MCP server tools correctly for efficient workflow bui
 
 ## Last Updated
 
-2025-10-20
+2026-02-18
 
 ---
 

--- a/skills/n8n-mcp-tools-expert/SEARCH_GUIDE.md
+++ b/skills/n8n-mcp-tools-expert/SEARCH_GUIDE.md
@@ -310,6 +310,66 @@ Step 4: Use in Workflow
 
 ---
 
+## n8n_list_credentials (NEW!)
+
+**Speed**: 50-200ms
+
+**Use when**: Need credential IDs for node configuration
+
+**Syntax**:
+```javascript
+n8n_list_credentials({
+  type: "slackApi",         // Optional: filter by credential type
+  name: "Production",       // Optional: filter by name (partial match)
+  limit: 50                 // Optional: max results (default 50)
+})
+```
+
+**Returns**: Credential metadata only (IDs and names, no secrets)
+
+**Common credential types**:
+- `slackApi`, `slackOAuth2Api`
+- `httpHeaderAuth`, `httpBasicAuth`
+- `googleSheetsOAuth2Api`, `gmailOAuth2Api`
+- `postgresApi`, `mysqlApi`
+- `openAiApi`, `anthropicApi`
+
+**Pattern**: Discover credentials → use in node config
+```javascript
+// Step 1: Find Slack credentials
+const creds = await n8n_list_credentials({type: "slackApi"});
+// → [{id: "abc123", name: "Production Slack", type: "slackApi"}]
+
+// Step 2: Use credential ID in workflow node
+{
+  type: "n8n-nodes-base.slack",
+  credentials: {slackApi: {id: "abc123", name: "Production Slack"}}
+}
+```
+
+---
+
+## n8n_sync_installed_nodes (NEW!)
+
+**Speed**: 200-500ms
+
+**Use when**: First connection to n8n instance, or after installing community nodes
+
+**Syntax**:
+```javascript
+n8n_sync_installed_nodes({
+  resetBeforeSync: false,  // Optional: reset all installed flags first
+  includeCore: true        // Optional: mark core nodes as installed
+})
+```
+
+**Effect**: After sync, `search_nodes` defaults to showing only installed nodes
+
+**Requires**: N8N_API_URL + N8N_API_KEY
+**Optional**: N8N_USER_EMAIL + N8N_USER_PASSWORD (for community package discovery)
+
+---
+
 ## Examples
 
 ### Find and Configure HTTP Request

--- a/skills/n8n-mcp-tools-expert/SKILL.md
+++ b/skills/n8n-mcp-tools-expert/SKILL.md
@@ -30,6 +30,9 @@ n8n-mcp provides tools organized into categories:
 | `search_nodes` | Finding nodes by keyword | <20ms |
 | `get_node` | Understanding node operations (detail="standard") | <10ms |
 | `validate_node` | Checking configurations (mode="full") | <100ms |
+| `n8n_find_workflow` | Search workflows by name before creating | 50-200ms |
+| `n8n_list_credentials` | Discover credential IDs for node config | 50-200ms |
+| `n8n_sync_installed_nodes` | Sync local DB with n8n instance | 200-500ms |
 | `n8n_create_workflow` | Creating workflows | 100-500ms |
 | `n8n_update_partial_workflow` | Editing workflows (MOST USED!) | 50-200ms |
 | `validate_workflow` | Checking complete workflow | 100-500ms |
@@ -80,11 +83,12 @@ get_node({nodeType: "nodes-base.slack", mode: "docs"})
 
 **Workflow**:
 ```
-1. n8n_create_workflow({name, nodes, connections})
-2. n8n_validate_workflow({id})
-3. n8n_update_partial_workflow({id, operations: [...]})
-4. n8n_validate_workflow({id}) again
-5. n8n_update_partial_workflow({id, operations: [{type: "activateWorkflow"}]})
+1. n8n_find_workflow({name: "My Workflow"})  ← NEW: prevent duplicates
+2. n8n_create_workflow({name, nodes, connections, activate: true})  ← NEW: activate param
+3. n8n_validate_workflow({id})
+4. n8n_update_partial_workflow({id, operations: [...]})
+5. n8n_validate_workflow({id}) again
+6. n8n_test_workflow({id, expectedOutput: {...}})  ← NEW: assertions
 ```
 
 **Common pattern**: iterative updates (56s average between edits)
@@ -497,6 +501,9 @@ n8n_health_check({mode: "diagnostic"})
 - tools_documentation, ai_agents_guide
 
 **Requires n8n API** (N8N_API_URL + N8N_API_KEY):
+- n8n_find_workflow
+- n8n_list_credentials
+- n8n_sync_installed_nodes
 - n8n_create_workflow
 - n8n_update_partial_workflow
 - n8n_validate_workflow (by ID)
@@ -507,7 +514,145 @@ n8n_health_check({mode: "diagnostic"})
 - n8n_workflow_versions
 - n8n_autofix_workflow
 
+**Requires n8n Internal API** (N8N_USER_EMAIL + N8N_USER_PASSWORD):
+- setPinData / clearPinData operations
+- updateDescription operation
+- n8n_sync_installed_nodes (community package discovery)
+
 If API tools unavailable, use templates and validation-only workflows.
+
+---
+
+## New Tools
+
+### n8n_find_workflow (PREVENT DUPLICATES!)
+
+**Use when**: Before creating workflows, to check if one with that name exists
+
+```javascript
+// Exact match
+n8n_find_workflow({name: "My Workflow", matchMode: "exact"})
+
+// Contains (default)
+n8n_find_workflow({name: "Webhook", matchMode: "contains"})
+
+// Fuzzy (typo-tolerant)
+n8n_find_workflow({name: "Webook to Slak", matchMode: "fuzzy"})
+```
+
+**Returns**: Matching workflows with webhook URLs, or null if not found
+
+**Pattern**: ALWAYS search before create!
+```javascript
+const existing = await n8n_find_workflow({name: "My Webhook"});
+if (existing) {
+  // Update existing workflow instead
+  n8n_update_partial_workflow({id: existing.id, ...});
+} else {
+  n8n_create_workflow({name: "My Webhook", ...});
+}
+```
+
+### n8n_list_credentials (DISCOVER CREDENTIALS!)
+
+**Use when**: Configuring nodes that need credentials
+
+```javascript
+// By type
+n8n_list_credentials({type: "slackApi"})
+
+// By name
+n8n_list_credentials({name: "Production Slack"})
+```
+
+**Returns**: Credential metadata (IDs and names, no secrets exposed)
+
+**Pattern**: Discover → Configure
+```javascript
+const creds = await n8n_list_credentials({type: "slackApi"});
+// Use cred.id in node configuration
+```
+
+### n8n_sync_installed_nodes (SETUP STEP!)
+
+**Use when**: First time connecting to an n8n instance, or after installing community nodes
+
+```javascript
+n8n_sync_installed_nodes()
+// After sync, search_nodes defaults to showing only installed nodes
+```
+
+**Requires**: N8N_API_URL + N8N_API_KEY (Public API)
+**Optional**: N8N_USER_EMAIL + N8N_USER_PASSWORD (for community package discovery via Internal API)
+
+---
+
+## Enhanced Tools
+
+### n8n_get_workflow: New mode="summary"
+
+Agent-friendly compact overview:
+```javascript
+n8n_get_workflow({id: "abc", mode: "summary"})
+// Returns: nodeCount, triggerType, webhookUrls, credentialsUsed
+```
+
+### n8n_create_workflow: New activate parameter
+
+Create and activate in one call:
+```javascript
+n8n_create_workflow({
+  name: "My Webhook",
+  nodes: [...],
+  connections: {...},
+  activate: true  // NEW: activates immediately
+})
+```
+
+### n8n_test_workflow: Assertion Support
+
+Automated PASS/FAIL testing:
+```javascript
+n8n_test_workflow({
+  id: "workflow-id",
+  testMode: "webhook",
+  webhookData: {message: "test"},
+  expectedOutput: {status: "ok"},  // NEW
+  assertionMode: "partial"         // NEW: "partial" or "exact"
+})
+// Returns: testResult: "PASS" or "FAIL" with field-level details
+```
+
+---
+
+## Internal API Operations
+
+**Requires**: N8N_USER_EMAIL + N8N_USER_PASSWORD (session-based auth)
+
+Three new operations for `n8n_update_partial_workflow`:
+
+### setPinData (Pin test data to nodes)
+```javascript
+{
+  type: "setPinData",
+  nodeName: "HTTP Request",
+  data: [{json: {id: 1, name: "Test"}}]
+}
+```
+
+### clearPinData (Clear pinned data)
+```javascript
+// Clear specific node
+{type: "clearPinData", nodeName: "HTTP Request"}
+
+// Clear all nodes
+{type: "clearPinData"}
+```
+
+### updateDescription (Set workflow description)
+```javascript
+{type: "updateDescription", description: "Processes incoming webhooks and forwards to Slack."}
+```
 
 ---
 
@@ -608,23 +753,30 @@ validate_node({nodeType: "nodes-base.webhook", config: {}, mode: "minimal"})
 ## Summary
 
 **Most Important**:
-1. Use **get_node** with `detail: "standard"` (default) - covers 95% of use cases
-2. nodeType formats differ: `nodes-base.*` (search/validate) vs `n8n-nodes-base.*` (workflows)
-3. Specify **validation profiles** (`runtime` recommended)
-4. Use **smart parameters** (`branch="true"`, `case=0`)
-5. Include **intent parameter** in workflow updates
-6. **Auto-sanitization** runs on ALL nodes during updates
-7. Workflows can be **activated via API** (`activateWorkflow` operation)
-8. Workflows are built **iteratively** (56s avg between edits)
+1. **ALWAYS search before create** with `n8n_find_workflow`
+2. Use **get_node** with `detail: "standard"` (default) - covers 95% of use cases
+3. nodeType formats differ: `nodes-base.*` (search/validate) vs `n8n-nodes-base.*` (workflows)
+4. Use `n8n_list_credentials` to discover credential IDs
+5. Specify **validation profiles** (`runtime` recommended)
+6. Use **smart parameters** (`branch="true"`, `case=0`)
+7. Include **intent parameter** in workflow updates
+8. Test workflows with assertions (`expectedOutput`)
+9. **Auto-sanitization** runs on ALL nodes during updates
+10. Workflows can be **activated via API** (`activateWorkflow` operation)
+11. Internal API enables pin data and description management
+12. Workflows are built **iteratively** (56s avg between edits)
 
 **Common Workflow**:
-1. search_nodes → find node
-2. get_node → understand config
-3. validate_node → check config
-4. n8n_create_workflow → build
-5. n8n_validate_workflow → verify
-6. n8n_update_partial_workflow → iterate
-7. activateWorkflow → go live!
+1. n8n_find_workflow → check for duplicates (NEW!)
+2. search_nodes → find node
+3. get_node → understand config
+4. n8n_list_credentials → find credentials (NEW!)
+5. validate_node → check config
+6. n8n_create_workflow → build (with activate: true)
+7. n8n_validate_workflow → verify
+8. n8n_update_partial_workflow → iterate
+9. n8n_test_workflow → test with assertions (NEW!)
+10. activateWorkflow → go live!
 
 For details, see:
 - [SEARCH_GUIDE.md](SEARCH_GUIDE.md) - Node discovery

--- a/skills/n8n-mcp-tools-expert/WORKFLOW_GUIDE.md
+++ b/skills/n8n-mcp-tools-expert/WORKFLOW_GUIDE.md
@@ -12,6 +12,44 @@ If unavailable, use template examples and validation-only workflows.
 
 ---
 
+## n8n_find_workflow (SEARCH BEFORE CREATE!)
+
+**Speed**: 50-200ms
+
+**Use when**: Before creating a new workflow, to prevent duplicates
+
+**Syntax**:
+```javascript
+n8n_find_workflow({
+  name: "Webhook to Slack",     // Required: workflow name to search
+  matchMode: "contains",        // Optional: exact, contains (default), fuzzy
+  activeOnly: false,            // Optional: only search active workflows
+  limit: 10                     // Optional: max results
+})
+```
+
+**Returns**: Matching workflows with webhook URLs, or null if not found
+
+**Match Modes**:
+- `exact` - Exact name match
+- `contains` (default) - Name contains query
+- `fuzzy` - Typo-tolerant with match scores
+
+**Pattern: Always search before create!**
+```javascript
+// Step 1: Check if workflow exists
+const existing = await n8n_find_workflow({name: "My Webhook"});
+
+// Step 2: Create or update
+if (existing) {
+  n8n_update_partial_workflow({id: existing.id, operations: [...]});
+} else {
+  n8n_create_workflow({name: "My Webhook", nodes: [...], connections: {...}});
+}
+```
+
+---
+
 ## n8n_create_workflow
 
 **Speed**: 100-500ms
@@ -73,6 +111,17 @@ n8n_create_workflow({
 - Auto-sanitization runs on creation
 - Validate before creating for best results
 
+**New**: Create and activate in one call:
+```javascript
+n8n_create_workflow({
+  name: "Webhook to Slack",
+  nodes: [...],
+  connections: {...},
+  activate: true  // Activates immediately after creation
+})
+// Returns: workflow with webhookUrls and activation status
+```
+
 ---
 
 ## n8n_update_partial_workflow (MOST USED!)
@@ -83,7 +132,7 @@ n8n_create_workflow({
 
 **Common pattern**: 56s average between edits (iterative building!)
 
-### 17 Operation Types
+### 20 Operation Types
 
 **Node Operations** (6 types):
 1. `addNode` - Add new node
@@ -109,6 +158,11 @@ n8n_create_workflow({
 **Activation Operations** (2 types):
 16. `activateWorkflow` - Activate workflow for automatic execution
 17. `deactivateWorkflow` - Deactivate workflow
+
+**Internal API Operations** (3 types, requires N8N_USER_EMAIL + N8N_USER_PASSWORD):
+18. `setPinData` - Pin test data to a node
+19. `clearPinData` - Clear pinned data from node(s)
+20. `updateDescription` - Set workflow description
 
 ### Intent Parameter (IMPORTANT!)
 
@@ -238,6 +292,46 @@ n8n_update_partial_workflow({
   operations: [{type: "deactivateWorkflow"}]
 })
 ```
+
+### Internal API Operations
+
+**Requires**: N8N_USER_EMAIL + N8N_USER_PASSWORD
+
+```javascript
+// Pin test data to a node for debugging
+n8n_update_partial_workflow({
+  id: "workflow-id",
+  intent: "Pin test data for debugging",
+  operations: [{
+    type: "setPinData",
+    nodeName: "HTTP Request",
+    data: [{json: {id: 1, name: "Test User", email: "test@example.com"}}]
+  }]
+})
+
+// Clear pinned data from specific node
+n8n_update_partial_workflow({
+  id: "workflow-id",
+  operations: [{type: "clearPinData", nodeName: "HTTP Request"}]
+})
+
+// Clear ALL pinned data
+n8n_update_partial_workflow({
+  id: "workflow-id",
+  operations: [{type: "clearPinData"}]
+})
+
+// Set workflow description
+n8n_update_partial_workflow({
+  id: "workflow-id",
+  operations: [{
+    type: "updateDescription",
+    description: "Processes incoming webhooks and forwards to Slack."
+  }]
+})
+```
+
+**Note**: These operations use the n8n Internal REST API (session-based authentication), not the Public API. They are optional and degrade gracefully if credentials are not configured.
 
 ### Example Usage
 
@@ -426,6 +520,20 @@ n8n_test_workflow({
 })
 ```
 
+### Assertion Support (NEW)
+
+Automated output validation:
+```javascript
+n8n_test_workflow({
+  id: "workflow-id",
+  testMode: "webhook",
+  webhookData: {message: "Hello!"},
+  expectedOutput: {status: "ok", processed: true},
+  assertionMode: "partial"  // "partial" (default) or "exact"
+})
+// Returns: testResult: "PASS" or "FAIL" with field-level details
+```
+
 ---
 
 ## n8n_validate_workflow (by ID)
@@ -455,6 +563,7 @@ n8n_validate_workflow({
 - `details` - Full + execution stats
 - `structure` - Nodes + connections only
 - `minimal` - ID, name, active, tags
+- `summary` (NEW) - Agent-friendly compact overview with webhook URLs, credentials used
 
 ```javascript
 // Full workflow
@@ -514,6 +623,10 @@ n8n_executions({
 
 **Standard pattern**:
 ```
+0. SEARCH (prevent duplicates)
+   n8n_find_workflow({name: "..."})
+   → Check if exists already
+
 1. CREATE
    n8n_create_workflow({...})
    → Returns workflow ID
@@ -608,9 +721,12 @@ update → update → update → ... (56s avg between edits)
 8. Use **n8n_deploy_template** for quick starts
 
 **New Tools**:
+- `n8n_find_workflow` - Search before create (NEW!)
+- `n8n_list_credentials` - Discover credential IDs (NEW!)
+- `n8n_sync_installed_nodes` - Sync with n8n instance (NEW!)
 - `n8n_deploy_template` - Deploy templates directly
 - `n8n_workflow_versions` - Version control & rollback
-- `n8n_test_workflow` - Trigger execution
+- `n8n_test_workflow` - Trigger execution with assertions
 - `n8n_executions` - Manage executions
 
 **Related**:

--- a/skills/n8n-node-configuration/README.md
+++ b/skills/n8n-node-configuration/README.md
@@ -346,10 +346,15 @@ get_node_essentials({nodeType: "nodes-base.slack"});
 ## Related Documentation
 
 - **n8n-mcp MCP Server**: Provides discovery tools
-- **n8n Node API**: get_node_essentials, get_property_dependencies, get_node_info
+- **n8n Node API**: get_node_essentials, get_property_dependencies, get_node_info, n8n_list_credentials
 - **n8n Schema**: displayOptions mechanism, property definitions
 
 ## Version History
+
+- **v1.1** (2026-02-18): Added credential discovery
+  - n8n_list_credentials tool integration
+  - Credential discovery workflow step
+  - Updated best practices
 
 - **v1.0** (2025-10-20): Initial implementation
   - SKILL.md with configuration workflow

--- a/skills/n8n-node-configuration/SKILL.md
+++ b/skills/n8n-node-configuration/SKILL.md
@@ -105,6 +105,8 @@ Configuration best practices:
    ↓
 2. Use get_node (standard detail is default)
    ↓
+2.5. Discover credentials → n8n_list_credentials({type: "..."})
+   ↓
 3. Configure required fields
    ↓
 4. Validate configuration
@@ -132,6 +134,12 @@ const info = get_node({
 });
 
 // Returns: method, url, sendBody, body, authentication required/optional
+```
+
+**Step 2.5**: Discover credentials
+```javascript
+const creds = n8n_list_credentials({type: "httpHeaderAuth"});
+// Returns: [{id: "abc123", name: "API Header Auth"}]
 ```
 
 **Step 3**: Minimal config
@@ -729,6 +737,11 @@ get_node({
    - Don't manually add/remove singleValue
    - IF/Switch metadata added on save
 
+6. **Discover credentials before configuring**
+   - Use `n8n_list_credentials({type: "..."})` to find credential IDs
+   - Never hardcode credential IDs without verifying they exist
+   - Filter by type to find the right credential
+
 ### ❌ Don't
 
 1. **Jump to detail="full" immediately**
@@ -766,11 +779,12 @@ For comprehensive guides on specific topics:
 
 **Configuration Strategy**:
 1. Start with `get_node` (standard detail is default)
-2. Configure required fields for operation
-3. Validate configuration
-4. Search properties if stuck
-5. Iterate until valid (avg 2-3 cycles)
-6. Deploy with confidence
+2. Discover credentials with n8n_list_credentials
+3. Configure required fields for operation
+4. Validate configuration
+5. Search properties if stuck
+6. Iterate until valid (avg 2-3 cycles)
+7. Deploy with confidence
 
 **Key Principles**:
 - **Operation-aware**: Different operations = different requirements

--- a/skills/n8n-validation-expert/README.md
+++ b/skills/n8n-validation-expert/README.md
@@ -272,10 +272,17 @@ if (preview.fixCount > 0) {
 ## Related Documentation
 
 - **n8n-mcp MCP Server**: Provides validation tools
-- **n8n Validation API**: validate_node_operation, validate_workflow, n8n_autofix_workflow
+- **n8n Validation API**: validate_node_operation, validate_workflow, n8n_autofix_workflow, n8n_test_workflow
+- **n8n Workflow API**: n8n_update_partial_workflow (setPinData, clearPinData operations)
 - **n8n Issues**: #304 (IF metadata), #306 (Switch branches), #338 (credentials)
 
 ## Version History
+
+- **v1.1** (2026-02-18): Added debugging features
+  - Pin data debugging with setPinData/clearPinData
+  - Assertion testing with expectedOutput
+  - Strategy 5: Pin Data for Debugging
+  - Updated best practices
 
 - **v1.0** (2025-10-20): Initial implementation
   - SKILL.md with core concepts

--- a/skills/n8n-validation-expert/SKILL.md
+++ b/skills/n8n-validation-expert/SKILL.md
@@ -630,6 +630,38 @@ n8n_autofix_workflow({
 })
 ```
 
+### Strategy 5: Pin Data for Debugging
+**When**: Workflow executes but produces unexpected output
+
+**Steps**:
+```javascript
+// Pin known test data to isolate the problem
+n8n_update_partial_workflow({
+  id: "workflow-id",
+  operations: [{
+    type: "setPinData",
+    nodeName: "HTTP Request",
+    data: [{json: {id: 1, name: "Test", status: "active"}}]
+  }]
+})
+
+// Test with pinned data
+n8n_test_workflow({
+  id: "workflow-id",
+  expectedOutput: {processed: true},
+  assertionMode: "partial"
+})
+// → testResult: "PASS" or "FAIL" with details
+
+// Clear pin data when done
+n8n_update_partial_workflow({
+  id: "workflow-id",
+  operations: [{type: "clearPinData", nodeName: "HTTP Request"}]
+})
+```
+
+**Requires**: N8N_USER_EMAIL + N8N_USER_PASSWORD for setPinData/clearPinData
+
 ---
 
 ## Best Practices
@@ -644,6 +676,8 @@ n8n_autofix_workflow({
 - Trust auto-sanitization for operator issues
 - Use `get_node` when unclear about requirements
 - Document false positives you accept
+- Use pin data (setPinData) to isolate debugging issues
+- Test with assertions (expectedOutput) for automated validation
 
 ### ❌ Don't
 

--- a/skills/n8n-workflow-patterns/README.md
+++ b/skills/n8n-workflow-patterns/README.md
@@ -38,6 +38,9 @@ Teaches architectural patterns for building n8n workflows. Provides structure, b
 - get_node (understand node operations)
 - search_templates (find example workflows)
 - ai_agents_guide (AI pattern guidance)
+- n8n_find_workflow (search before create)
+- n8n_list_credentials (discover credentials)
+- n8n_test_workflow (test with assertions)
 
 **Related skills**:
 - n8n MCP Tools Expert (find and configure nodes)
@@ -85,12 +88,13 @@ Teaches architectural patterns for building n8n workflows. Provides structure, b
 
 ## Evaluations
 
-5 scenarios (100% coverage expected):
+6 scenarios (100% coverage expected):
 1. **eval-001**: Webhook workflow structure
 2. **eval-002**: HTTP API integration pattern
 3. **eval-003**: Database sync pattern
 4. **eval-004**: AI agent workflow with tools
 5. **eval-005**: Scheduled report generation
+6. **eval-006**: Search before create pattern
 
 ## Key Features
 
@@ -243,7 +247,7 @@ Use `search_templates` to find examples for your use case!
 
 ## Last Updated
 
-2025-10-20
+2026-02-18
 
 ---
 

--- a/skills/n8n-workflow-patterns/SKILL.md
+++ b/skills/n8n-workflow-patterns/SKILL.md
@@ -112,6 +112,7 @@ All patterns share these building blocks:
 When building ANY workflow, follow this checklist:
 
 ### Planning Phase
+- [ ] Search for existing workflows (use n8n_find_workflow to prevent duplicates)
 - [ ] Identify the pattern (webhook, API, database, AI, scheduled)
 - [ ] List required nodes (use search_nodes)
 - [ ] Understand data flow (input → transform → output)
@@ -121,6 +122,7 @@ When building ANY workflow, follow this checklist:
 - [ ] Create workflow with appropriate trigger
 - [ ] Add data source nodes
 - [ ] Configure authentication/credentials
+- [ ] Discover credentials (use n8n_list_credentials)
 - [ ] Add transformation nodes (Set, Code, IF)
 - [ ] Add output/action nodes
 - [ ] Configure error handling
@@ -129,11 +131,13 @@ When building ANY workflow, follow this checklist:
 - [ ] Validate each node configuration (validate_node)
 - [ ] Validate complete workflow (validate_workflow)
 - [ ] Test with sample data
+- [ ] Test with assertions (use n8n_test_workflow with expectedOutput)
 - [ ] Handle edge cases (empty data, errors)
 
 ### Deployment Phase
 - [ ] Review workflow settings (execution order, timeout, error handling)
-- [ ] Activate workflow using `activateWorkflow` operation
+- [ ] Activate workflow (use `activate: true` in create, or `activateWorkflow` operation)
+- [ ] Pin test data for debugging (use setPinData operation)
 - [ ] Monitor first executions
 - [ ] Document workflow purpose and data flow
 
@@ -229,6 +233,10 @@ These skills work together with Workflow Patterns:
 - Create workflows (n8n_create_workflow)
 - Deploy templates (n8n_deploy_template)
 - Use ai_agents_guide for AI pattern guidance
+- Search for existing workflows before creating (n8n_find_workflow)
+- Discover credentials for node configuration (n8n_list_credentials)
+- Test workflows with assertions (n8n_test_workflow)
+- Pin test data for debugging (setPinData operation)
 
 **n8n Expression Syntax** - Use to:
 - Write expressions in transformation nodes
@@ -374,6 +382,10 @@ Use `search_templates` and `get_template` from n8n-mcp tools to find examples!
 - Use descriptive node names
 - Document complex workflows (notes field)
 - Monitor workflow executions after deployment
+- Search for existing workflows before creating new ones
+- Discover credentials with n8n_list_credentials before configuring
+- Test workflows with assertions (expectedOutput) before activation
+- Use pin data (setPinData) for debugging complex transformations
 
 ### ❌ Don't
 
@@ -385,6 +397,8 @@ Use `search_templates` and `get_template` from n8n-mcp tools to find examples!
 - Forget to handle empty data cases
 - Mix multiple patterns without clear boundaries
 - Deploy without testing
+- Create workflows without searching for duplicates first
+- Hardcode credential IDs without discovering them first
 
 ---
 


### PR DESCRIPTION
## Summary

- Update 4 skills to reflect new n8n-mcp capabilities added in the `feature/internal-api-session-auth` branch
- Add 3 new tools documentation: `n8n_find_workflow`, `n8n_list_credentials`, `n8n_sync_installed_nodes`
- Document 3 new Internal API operations: `setPinData`, `clearPinData`, `updateDescription`
- Document enhanced tool features: `get_workflow` summary mode, `create_workflow` activate param, `test_workflow` assertions
- Update operation count from 17 to 20 across all documentation
- Add 4 new evaluation test scenarios

## Skills Updated

| Skill | Changes |
|-------|---------|
| **n8n-mcp-tools-expert** | New tools, Internal API ops, enhanced tools, updated workflow lifecycle |
| **n8n-workflow-patterns** | Search-before-create pattern, credential discovery, assertion testing, pin data debugging |
| **n8n-node-configuration** | Credential discovery step in configuration workflow |
| **n8n-validation-expert** | Pin data debugging strategy, assertion-based testing |

## New Evaluations

- `eval-006-search-before-create.json` (mcp-tools)
- `eval-007-credential-discovery.json` (mcp-tools)
- `eval-008-internal-api-operations.json` (mcp-tools)
- `eval-006-search-before-create.json` (workflow-patterns)

## Test plan

- [ ] Verify all skill markdown files render correctly
- [ ] Run evaluation scenarios against updated skills
- [ ] Confirm new tool references match actual n8n-mcp API
- [ ] Check cross-references between skills are consistent

Conceived by Romuald Członkowski - www.aiadvisors.pl/en

🤖 Generated with [Claude Code](https://claude.com/claude-code)