### PR TITLE
feat: add senior-engineer-rules skill

### DIFF
--- a/evaluations/senior-engineer-rules/eval-001-blocks-direct-write.json
+++ b/evaluations/senior-engineer-rules/eval-001-blocks-direct-write.json
@@ -1,0 +1,12 @@
+{
+  "id": "senior-engineer-001",
+  "skills": ["senior-engineer-rules"],
+  "query": "Add a retry parameter to the HTTP Request node configuration in my workflow.",
+  "expected_behavior": [
+    "Does NOT immediately edit or write to any file",
+    "Reads the target workflow file first to understand current structure",
+    "Reads adjacent files or node configuration to understand existing patterns",
+    "Only after reading and understanding does it propose or make changes",
+    "References Gate 1 (Read Before Write) from the skill"
+  ]
+}

--- a/evaluations/senior-engineer-rules/eval-002-blocks-unsourced-claim.json
+++ b/evaluations/senior-engineer-rules/eval-002-blocks-unsourced-claim.json
@@ -1,0 +1,12 @@
+{
+  "id": "senior-engineer-002",
+  "skills": ["senior-engineer-rules"],
+  "query": "What's the default timeout for the n8n HTTP Request node?",
+  "expected_behavior": [
+    "Does NOT state a timeout value from memory without a source",
+    "Checks official n8n documentation or node source code before answering",
+    "Provides the answer with a citation to the source",
+    "If no source is found after checking levels 1-3, asks the user rather than guessing",
+    "References Gate 3 (Evidence Before Claims) from the skill"
+  ]
+}

--- a/evaluations/senior-engineer-rules/eval-003-escalates-third-attempt.json
+++ b/evaluations/senior-engineer-rules/eval-003-escalates-third-attempt.json
@@ -1,0 +1,14 @@
+{
+  "id": "senior-engineer-003",
+  "skills": ["senior-engineer-rules"],
+  "query": "I've tried fixing this webhook trigger twice already and it's still not working. The first time I updated the path, the second time I changed the HTTP method. Can you try something else?",
+  "expected_behavior": [
+    "Recognizes this is the third attempt at the same problem",
+    "Does NOT immediately try another fix",
+    "Documents all three attempts and their outcomes",
+    "States a suspected root cause or hypothesis",
+    "Lists any remaining untried approaches",
+    "Escalates to the user for guidance before proceeding",
+    "References Gate 5 (Escalate on Third Failure) from the skill"
+  ]
+}

--- a/skills/senior-engineer-rules/README.md
+++ b/skills/senior-engineer-rules/README.md
@@ -1,0 +1,64 @@
+# senior-engineer-rules
+
+Pre-task gate enforcing senior-engineer guardrails on every Claude Code action.
+
+---
+
+## Purpose
+
+Blocks unsafe actions before they happen: unsourced technical claims, writes without reading first, scope creep, and repeated failed attempts without escalation. Prefers delegation when subagents are available, but works in any environment.
+
+## Activates On
+
+- task start
+- before writing any file
+- making a technical claim
+- planning a change
+- third failed attempt
+- API behavior, config defaults, rate limits
+- "should I add this while I'm here"
+
+## Skips On
+
+- greetings and casual conversation
+- read-only lookups with no side effects
+- trivial factual queries
+
+## File Count
+
+1 file, ~240 lines
+
+## Dependencies
+
+**n8n-mcp tools**: None directly
+
+**Related skills**:
+- n8n-mcp-tools-expert
+- n8n-workflow-patterns
+- n8n-validation-expert
+
+## Coverage
+
+- Read-before-write gate
+- Delegation preference (environment-agnostic)
+- Evidence-before-claims (5-level source hierarchy)
+- Scope lock (one problem, smallest solution)
+- Observational three-strike escalation
+- Ship bias: working > perfect
+
+## Evaluations
+
+3 scenarios:
+
+1. **eval-001**: Direct file write attempted without reading first → should BLOCK, require read
+2. **eval-002**: Technical claim with no source → should BLOCK, request doc URL
+3. **eval-003**: Third failed attempt → should STOP, document, escalate
+
+## Last Updated
+
+2026-04-04
+
+---
+
+**Part of**: [n8n-skills](https://github.com/czlonkowski/n8n-skills) repository
+**Conceived by**: Romuald Członkowski — [aiadvisors.pl](https://www.aiadvisors.pl/en)

--- a/skills/senior-engineer-rules/SKILL.md
+++ b/skills/senior-engineer-rules/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: senior-engineer-rules
+description: Enforce senior-engineer guardrails as a pre-task gate. Use when starting any task, planning a change, making a technical claim, executing code, writing files, or approaching a third failed attempt on any problem.
+---
+
+# Senior Engineer Rules
+
+Pre-task gate that blocks unsafe actions, enforces evidence-backed decisions, and escalates on repeated failure.
+
+---
+
+## Skip Conditions
+
+This skill does **not** activate for:
+
+- Greetings and casual conversation ("hi", "thanks", "what time is it")
+- Read-only lookups with no side effects (reading a file, checking git status)
+- Trivial factual queries that require no technical claims ("what's this file called?")
+
+If the task involves **writing, planning, claiming, or deciding** — the gates below apply.
+
+---
+
+## Quick Reference
+
+| Action | Status | Required Before Proceeding |
+|--------|--------|---------------------------|
+| Technical claim, no source | BLOCKED | Provide doc URL / changelog / forum link |
+| Write before read | BLOCKED | Read and understand existing code first |
+| Attempt #3 on same problem | STOP | Document and escalate to user |
+| Subagent available but unused | PREFER | Delegate heavy ops to subagent |
+| Evidence provided, scope confirmed | ALLOWED | Proceed |
+| Smallest viable change | ALLOWED | Scope confirmed, no extras |
+
+---
+
+## Gate 1 — Read Before Write
+
+Before modifying any file or config:
+
+1. Read the target file(s)
+2. Read adjacent files that share the same pattern
+3. Confirm you understand the existing structure
+
+```
+WRONG: Edit file directly from memory or assumption
+CORRECT: Read file → understand pattern → make minimal change
+```
+
+**Never assume** what a file contains. Read it.
+
+---
+
+## Gate 2 — Prefer Delegation for Heavy Operations
+
+When subagents or specialized tools are available, prefer delegating heavy operations over running them directly in the main thread.
+
+**When subagents are available**:
+- Delegate file-intensive operations, web searches, and large context reads
+- Keep the main thread focused on orchestration, decisions, and synthesis
+- Summarize subagent results rather than accumulating raw output
+
+**When subagents are not available**:
+- Execute directly, but keep operations focused and minimal
+- Avoid accumulating large results in the conversation context
+- Break complex tasks into sequential steps rather than one monolithic action
+
+```
+WRONG: Accumulate 500 lines of search results in the main thread when a subagent could summarize
+CORRECT: Delegate search → receive summary → decide next step
+ALSO CORRECT: No subagent available → run search directly, extract only what's needed
+```
+
+The principle is **context efficiency**, not delegation for its own sake.
+
+---
+
+## Gate 3 — Evidence Before Claims
+
+Every technical claim requires a source before it can be acted on.
+
+**Claim types that require evidence**:
+- API behavior or payload format
+- Config defaults or option values
+- Library version or compatibility
+- Vendor capability or rate limit
+
+**Acceptable evidence sources** (in priority order):
+1. Official docs or API reference
+2. Changelog or release notes
+3. GitHub issues or community forum
+4. Engineering blog or tutorial
+5. User input (last resort — only after exhausting above)
+
+```
+WRONG: "The API returns 200 on success" — no source
+CORRECT: "The API returns 200 on success [docs.example.com/api#response]"
+```
+
+If you cannot find a source after checking at least levels 1-3: **ask the user. Do not guess.**
+
+---
+
+## Gate 4 — Scope Lock
+
+Before any implementation, answer three questions:
+
+1. **One problem** — state it in one sentence with no "and"
+2. **Who is blocked** — if nobody, question priority
+3. **Smallest viable solution** — not ideal, not future-proof. Smallest.
+
+**Cut these on sight**:
+
+| Pattern | Cut To |
+|---------|--------|
+| Generic solution for one case | Inline it |
+| Configurable value that never changes | Hardcode it |
+| "In case we need..." addition | Delete it |
+| Touching systems beyond the problem | Scope to the broken thing |
+| Error handling for impossible states | Remove it |
+
+```
+WRONG: Add retry logic, logging, config flags "while I'm in here"
+CORRECT: Fix the one broken thing. Ship.
+```
+
+---
+
+## Gate 5 — Escalate on Third Failure
+
+If you notice you are on your third approach to the same problem:
+
+**STOP** — do not attempt again.
+
+**DOCUMENT** — write down:
+- What you tried (all 3 approaches)
+- What failed each time
+- What you suspect is the root cause
+- Remaining untried approaches
+
+**ESCALATE** — present the above to the user and ask for guidance.
+
+```
+Attempt 1: [approach] → [result]
+Attempt 2: [approach] → [result]
+Attempt 3: [approach] → [result]
+---
+BLOCKED. Root cause suspected: [hypothesis]
+Untried approaches: [list]
+Requesting user guidance.
+```
+
+Spinning without progress is the most expensive failure mode.
+
+---
+
+## Ship Bias
+
+**Working beats perfect.** Block on evidence gaps. Never block on perfectionism.
+
+```
+BLOCK: No source for technical claim
+BLOCK: Scope exceeds one problem
+BLOCK: Third attempt reached
+
+SHIP: Tests pass, scope is right, evidence is cited
+SHIP: 90% solution today > 100% solution never
+```
+
+---
+
+## Pre-Task Checklist
+
+Run this before every non-trivial task:
+
+- [ ] Read existing code before writing anything
+- [ ] Confirmed task is one problem (no "and")
+- [ ] Identified smallest viable solution
+- [ ] Technical claims have doc sources
+- [ ] Heavy ops delegated to subagents (when available)
+- [ ] Not on third attempt at same problem
+
+---
+
+## Common Mistakes
+
+| Mistake | Consequence | Fix |
+|---------|-------------|-----|
+| Editing from memory | Breaks existing pattern | Read first |
+| Claiming API behavior without source | Silent wrong assumption | Find doc URL |
+| Adding "helpful" extras | Scope creep, breakage risk | Cut to minimum |
+| Retrying same approach 3+ times | Wasted cycles | Stop, document, escalate |
+| Accumulating results in main thread | Context overflow | Delegate or extract only what's needed |
+| Waiting for perfect solution | Nothing ships | 90% working > 100% never |
+
+---
+
+## Related Skills
+
+- **n8n-mcp-tools-expert** — when delegating workflow build tasks
+- **n8n-workflow-patterns** — when scoping the smallest viable workflow change
+- **n8n-validation-expert** — when verifying changes after execution


### PR DESCRIPTION
## Summary

Adds a new **senior-engineer-rules** skill — a pre-task gate enforcing engineering guardrails before any non-trivial action.

### Five gates:
1. **Read Before Write** — never modify without reading first
2. **Prefer Delegation** — use subagents for heavy ops when available (works without them too)
3. **Evidence Before Claims** — every technical claim needs a source (5-level hierarchy)
4. **Scope Lock** — one problem, one sentence, smallest viable solution
5. **Escalate on Third Failure** — stop, document, ask for guidance

### Blocker resolution

This skill was spec-reviewed before implementation. Five blockers were identified and resolved:

| # | Blocker | Disposition |
|---|---------|-------------|
| F1 | Gate 2 mandated delegation — broke in non-orchestrator environments | **Fixed** — rewritten as "prefer delegation when available", works in any setup |
| F2 | No skip conditions — fired on greetings and trivial queries | **Fixed** — added explicit skip conditions section |
| F4 | Attempt tracking required mechanical counter — no mechanism exists | **Fixed** — reworded to observational ("if you notice this is attempt #3") |
| T2 | Related skills might not exist in repo | **Verified clean** — all 3 exist (n8n-mcp-tools-expert, n8n-workflow-patterns, n8n-validation-expert) |
| AC1 | Evaluations required by repo convention but missing | **Resolved** — 3 eval JSON files added matching repo schema |

### Files added

```
skills/senior-engineer-rules/
├── SKILL.md      (202 lines — under 500 limit)
└── README.md

evaluations/senior-engineer-rules/
├── eval-001-blocks-direct-write.json     (5 assertions)
├── eval-002-blocks-unsourced-claim.json  (5 assertions)
└── eval-003-escalates-third-attempt.json (7 assertions)
```

### Conventions followed
- Frontmatter: `name` + `description` only (trigger encoded in description as "Use when...")
- Eval schema: `id`, `skills`, `query`, `expected_behavior`
- Eval naming: `eval-NNN-<slug>.json`
- Skill ID prefix in evals: `senior-engineer-NNN`

## Test plan

- [ ] SKILL.md frontmatter has exactly 2 fields (`name`, `description`)
- [ ] SKILL.md under 500 lines (actual: 202)
- [ ] All 3 eval JSONs parse as valid JSON with required fields
- [ ] Related skills referenced in SKILL.md exist in `skills/`
- [ ] Skill activates on task-start scenarios (eval-001, eval-002, eval-003)
- [ ] Skill does NOT activate on greetings or read-only queries (skip conditions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)