### PR TITLE
docs: add Data Table node (nodes-base.dataTable) reference

### DIFF
--- a/skills/n8n-mcp-tools-expert/SKILL.md
+++ b/skills/n8n-mcp-tools-expert/SKILL.md
@@ -459,6 +459,12 @@ n8n_deploy_template({
 
 ## Data Table Management
 
+> **Two surfaces, don't confuse them:**
+> - **`n8n_manage_datatable` (below)** — MCP tool for managing tables and rows from *outside* a workflow (e.g. creating tables during workflow scaffolding, seeding data, or inspecting state from Claude). Covered here.
+> - **`nodes-base.dataTable` node** — the in-workflow node you drop into a workflow to read/write rows *during execution*. For its parameter shapes, operation values, filter syntax, and gotchas (e.g. the `deleteRows` reserved-word workaround, the `id isNotEmpty` trick for "all rows"), see [n8n-node-configuration → OPERATION_PATTERNS.md → Storage Nodes → Data Table](../n8n-node-configuration/OPERATION_PATTERNS.md#data-table-nodes-basedatatable).
+>
+> Rule of thumb: use the MCP tool to set up a table once and the workflow node to read/write rows on every execution.
+
 ### n8n_manage_datatable
 
 Unified tool for managing n8n data tables and rows. Supports CRUD operations on tables and rows with filtering, pagination, and dry-run support.

--- a/skills/n8n-node-configuration/OPERATION_PATTERNS.md
+++ b/skills/n8n-node-configuration/OPERATION_PATTERNS.md
@@ -462,6 +462,168 @@ Database operations - 456 templates
 
 ---
 
+## Storage Nodes
+
+### Data Table (nodes-base.dataTable)
+
+Persistent, structured per-project key-value storage — an in-n8n alternative to external SQL for small state like buffers, de-dup sets, counters, or lookup caches. **Do not confuse with the MCP tool `n8n_manage_datatable`** — that tool manages tables from outside n8n (create/list/delete tables and rows from Claude). The **`nodes-base.dataTable` node** below is what you drop *into a workflow* to read/write rows during execution.
+
+> **Verified end-to-end against live n8n on 2026-04-08** with a 15-node assertion harness exercising every claim below: insert returning rows with system `id`, `like` operator, `returnAll`, `allConditions` AND-of-multiple-filters, `isTrue` unary boolean condition, `upsert` with `matchingColumns` (no duplicates), `defineBelow` resourceMapper writing values, `deleteRows` (the reserved-word workaround) returning affected rows, and `dataTableId` resourceLocator in `mode: "name"`. All 6 assertions passed.
+
+**Node shape**:
+- `type`: `n8n-nodes-base.dataTable`
+- `typeVersion`: `1.1` (also `1`)
+- `resource`: `"row"` or `"table"`
+- Row `operation` values — note the reserved-word workaround on delete:
+  - `"insert"` — Insert row
+  - `"get"` — Get row(s)
+  - `"update"` — Update row(s) matching conditions
+  - `"upsert"` — Update if match, else insert
+  - `"deleteRows"` — Delete row(s) matching conditions (**not `"delete"`** — `delete` is a JS reserved word, the node uses `deleteRows`)
+  - `"rowExists"` — Pass through input if at least one match
+  - `"rowNotExists"` — Pass through input if zero matches
+
+**Table selection** — always a resourceLocator parameter named `dataTableId`:
+```javascript
+"dataTableId": {
+  "__rl": true,
+  "mode": "list",      // or "name" or "id"
+  "value": "dt_xyz123" // or the name when mode=name
+}
+```
+
+**Row mapping** (insert/update/upsert) — resourceMapper parameter named `columns`:
+```javascript
+"columns": {
+  "mappingMode": "defineBelow",    // or "autoMapInputData"
+  "value": {
+    "user_email": "={{ $json.email }}",
+    "score": "={{ $json.score }}",
+    "active": true
+  },
+  "matchingColumns": [],           // filled for update/upsert match keys
+  "schema": [],                    // n8n re-loads at runtime; safe to leave empty
+  "attemptToConvertTypes": false,
+  "convertFieldsToString": false
+}
+```
+In `autoMapInputData` mode, incoming item field names must match column names exactly and `value` is ignored.
+
+**Filtering** (get/update/upsert/deleteRows/rowExists/rowNotExists):
+```javascript
+"matchType": "anyCondition",   // or "allConditions"
+"filters": {
+  "conditions": [
+    { "keyName": "user_email", "condition": "eq",        "keyValue": "a@b.com" },
+    { "keyName": "score",      "condition": "gte",       "keyValue": 10 },
+    { "keyName": "archived",   "condition": "isNotEmpty"  }
+  ]
+}
+```
+Supported `condition` values: `eq, neq, like, ilike, gt, gte, lt, lte, isEmpty, isNotEmpty, isTrue, isFalse`. The last four are unary — omit `keyValue`.
+
+**Get options**: `returnAll: true` bypasses the default 50-row limit. `options` can include ordering.
+
+**Insert option**: `options.optimizeBulk: true` skips returning inserted rows for ~5x bulk throughput. Do not use when downstream nodes need the inserted row ids.
+
+**Mutating ops** (update/upsert/deleteRows) accept `options.dryRun: true` — returns the rows that *would* be affected with before/after states, without writing.
+
+#### Minimal Insert
+```javascript
+{
+  "resource": "row",
+  "operation": "insert",
+  "dataTableId": { "__rl": true, "mode": "name", "value": "email_buffer" },
+  "columns": {
+    "mappingMode": "defineBelow",
+    "value": {
+      "from_name": "={{ $json.from_name }}",
+      "subject":   "={{ $json.subject }}"
+    },
+    "matchingColumns": [],
+    "schema": []
+  },
+  "options": {}
+}
+```
+
+#### Get All Rows
+`Get` requires at least one condition — a bare "return everything" isn't allowed. Trick: filter on the always-populated system `id` column with `isNotEmpty`.
+```javascript
+{
+  "resource": "row",
+  "operation": "get",
+  "dataTableId": { "__rl": true, "mode": "name", "value": "email_buffer" },
+  "matchType": "anyCondition",
+  "filters": {
+    "conditions": [ { "keyName": "id", "condition": "isNotEmpty" } ]
+  },
+  "returnAll": true,
+  "options": {}
+}
+```
+
+#### Delete All Rows
+Same `id isNotEmpty` trick — a delete without conditions throws `At least one condition is required`.
+```javascript
+{
+  "resource": "row",
+  "operation": "deleteRows",
+  "dataTableId": { "__rl": true, "mode": "name", "value": "email_buffer" },
+  "matchType": "anyCondition",
+  "filters": {
+    "conditions": [ { "keyName": "id", "condition": "isNotEmpty" } ]
+  },
+  "options": {}
+}
+```
+
+#### Upsert by Natural Key
+```javascript
+{
+  "resource": "row",
+  "operation": "upsert",
+  "dataTableId": { "__rl": true, "mode": "name", "value": "user_scores" },
+  "matchType": "allConditions",
+  "filters": {
+    "conditions": [ { "keyName": "user_email", "condition": "eq", "keyValue": "={{ $json.email }}" } ]
+  },
+  "columns": {
+    "mappingMode": "defineBelow",
+    "value": {
+      "user_email": "={{ $json.email }}",
+      "score":      "={{ $json.score }}"
+    },
+    "matchingColumns": ["user_email"],
+    "schema": []
+  },
+  "options": {}
+}
+```
+
+**System columns**: every table auto-has `id` plus created/updated timestamps — you don't declare these and can't write to them. They're usable in filters.
+
+**When to reach for Data Table vs alternatives**:
+
+| Need | Use |
+|------|-----|
+| Small per-workflow scratch state, single workflow, not durable across workflow edits | `$getWorkflowStaticData('global')` inside a Code node |
+| Persistent structured state, queryable by column, survives workflow rename/edit/deactivation, shared across multiple workflows in the same project | **Data Table node** |
+| Large datasets (>>10k rows), complex joins, transactions, FKs, indexes | External Postgres/MySQL |
+| Unstructured key-value cache with TTL | Redis |
+
+**Gotchas**:
+- Scope is **per project** — Data Tables are not shared across n8n projects. Move a workflow to another project and its Data Table references break.
+- Filter operator `eq` on a column that doesn't exist in the table returns a validation error at execution, not at import — always verify column names match the live table.
+- Expression values in `columns.value` are evaluated per input item. If the upstream node emits N items, Insert runs N times unless you explicitly use `optimizeBulk`.
+- `deleteRows` is the operation value, not `delete`. Using `delete` will import but fail at execution with "unknown operation".
+- Race condition in buffer/flush patterns: rows added between `Get` and `deleteRows` will be wiped without being read. For at-least-once semantics, delete by specific row ids returned from `Get` instead of by a broad filter.
+- **Zero-match halts the chain.** When `get`, `deleteRows`, `update`, or `upsert` matches 0 rows, the node emits 0 output items and n8n stops the downstream branch silently — no error, just nothing happens. This bites cleanup steps in idempotent test/setup workflows where the table starts empty. Fix: set node-level `"alwaysOutputData": true` (sibling of `parameters`/`type`, NOT inside `parameters`) on any DT node that may legitimately match nothing. The node will then emit a single empty item and the chain continues.
+- **DT operations execute once per input item.** A `Get` node fed 3 input items will run 3 separate queries and concatenate the results — usually not what you want. Insert a "collapse" Code node (`return [{ json: {} }];`) between any multi-item-emitting node and a downstream DT op that should run exactly once.
+- DT nodes do not natively offer a "run once for all items" mode like the Code node — the collapse-node pattern is currently the only clean workaround.
+
+---
+
 ## Data Transformation Nodes
 
 ### Set (nodes-base.set)


### PR DESCRIPTION
## Summary

The in-workflow **Data Table node** (`n8n-nodes-base.dataTable`) is not currently documented in the skills library. Only the external MCP management tool `n8n_manage_datatable` is covered, which is a different surface — that tool manages tables and rows from outside n8n (e.g. from Claude during workflow scaffolding), whereas the in-workflow node is what you drop into a workflow to read/write rows during execution. Easy to confuse, no signposting between the two.

This PR adds reference coverage for the in-workflow node, plus a short disambiguation callout in the MCP tools skill that points readers to it.

## What's added

**`skills/n8n-node-configuration/OPERATION_PATTERNS.md`** — new "Storage Nodes → Data Table" section (+162 lines) covering:

- Node shape (`type`, `typeVersion`, `resource`, `operation` values)
- The `dataTableId` resource locator with all three modes (`list`, `name`, `id`)
- The `columns` resource mapper for insert/update/upsert (`defineBelow` and `autoMapInputData` modes)
- Filter syntax (`matchType`, `filters.conditions[]`, full operator list including the unary boolean conditions)
- Four worked examples: minimal insert, get-all-rows trick, delete-all-rows trick, upsert by natural key with `matchingColumns`
- "When to use Data Table vs alternatives" decision table comparing it against `$getWorkflowStaticData`, external SQL, and Redis
- Gotchas list (see below)

**`skills/n8n-mcp-tools-expert/SKILL.md`** — short disambiguation callout (+6 lines) at the top of the existing "Data Table Management" section, distinguishing the MCP tool from the workflow node and linking to the new section.

## Gotchas documented (the interesting ones)

A few of these are not in the n8n source comments or the official docs — they came out of building and live-testing a real workflow:

- **`deleteRows`, not `delete`.** The operation value for delete is `deleteRows` because `delete` is a JS reserved word. Using `delete` imports but fails at execution with "unknown operation" — a confusing error since the docs use the word "Delete".
- **Get/Delete without a condition is rejected.** A bare "return everything" isn't allowed; the trick is to filter on the always-populated system `id` column with `isNotEmpty`.
- **Per-input-item execution.** A `Get` node fed N input items runs N separate queries and concatenates results — usually not what you want. The skill documents the "collapse to 1 item" Code-node workaround.
- **Zero-match halts the chain** (related to #10). Any DT op that matches 0 rows emits 0 output items and n8n silently stops the downstream branch. Fix: node-level `alwaysOutputData: true`. This is the same root cause as the database-write-node case in #10; documenting it here for the Data Table node specifically because it bites cleanup steps in idempotent setup workflows on an empty table.

## Verification

End-to-end tested against a live n8n instance on 2026-04-08 with a 15-node assertion harness that exercises every claim in the new section. All 6 assertions passed:

| # | Claim | Result |
|---|---|---|
| 1 | `insert` returns inserted rows with system `id` populated | ✅ |
| 2 | `get` with `condition: "like"` + `returnAll: true` | ✅ |
| 3 | `get` with `matchType: "allConditions"` AND `isTrue` (unary, no `keyValue`) | ✅ |
| 4 | `upsert` with `matchingColumns` updates instead of inserting a duplicate | ✅ |
| 5 | `defineBelow` resourceMapper actually writes new column values | ✅ |
| 6 | `deleteRows` returns the affected rows as output items | ✅ |

The test workflow JSON is small (~15 nodes, fully self-contained, idempotent, scoped to test rows so it's safe to run against a live table with real data). Happy to add it to the repo under `evaluations/` or `examples/` if useful — let me know and I'll push a follow-up commit.

## Compatibility notes

- Strictly additive: +168 / -0, no existing content modified.
- Rebases cleanly on current `main` (verified locally — no conflicts with recent `feat: Document n8n_manage_credentials and n8n_audit_instance tools`).
- Does not touch the same files as #12 in any conflicting way.

## Related

- #10 (`docs: document alwaysOutputData for database write nodes`) — independently surfaces the same `alwaysOutputData` gotcha, but for database write nodes hit in production. Two independent reproductions of the same root cause on different node types feels like reasonable supporting evidence that this is worth documenting in both places.
