### PR TITLE
fix: quote YAML frontmatter descriptions in two skills

### DIFF
--- a/skills/n8n-code-tool/SKILL.md
+++ b/skills/n8n-code-tool/SKILL.md
@@ -1,6 +1,20 @@
 ---
 name: n8n-code-tool
-description: Write JavaScript or Python for the n8n Custom Code Tool (@n8n/n8n-nodes-langchain.toolCode) — the AI-agent-callable tool, NOT the workflow Code node. Use when building a Code Tool attached to an AI Agent, writing code that an LLM will invoke, parsing the `query` input, returning a string result, defining an input schema for structured arguments (specifyInputSchema, jsonSchemaExample, DynamicStructuredTool), or troubleshooting errors like "Wrong output type returned", "No execution data available", "The response property should be a string, but it is an object", "Cannot assign to read only property 'name'", or an AI agent that refuses to call the tool. Covers the critical differences between Code node and Code Tool: return format (string vs `[{json:{...}}]`), unavailability of `$fromAI`/`$input`/`$helpers` in the Code Tool sandbox, naming rules for AI invocation, and when to use `toolWorkflow`/HTTP Request Tool instead.
+description: >-
+  Write JavaScript or Python for the n8n Custom Code Tool
+  (@n8n/n8n-nodes-langchain.toolCode) — the AI-agent-callable tool, NOT the
+  workflow Code node. Use when building a Code Tool attached to an AI Agent,
+  writing code that an LLM will invoke, parsing the `query` input, returning a
+  string result, defining an input schema for structured arguments
+  (specifyInputSchema, jsonSchemaExample, DynamicStructuredTool), or
+  troubleshooting errors like "Wrong output type returned", "No execution data
+  available", "The response property should be a string, but it is an object",
+  "Cannot assign to read only property 'name'", or an AI agent that refuses to
+  call the tool. Covers the critical differences between Code node and Code
+  Tool: return format (string vs `[{json:{...}}]`), unavailability of
+  `$fromAI`/`$input`/`$helpers` in the Code Tool sandbox, naming rules for AI
+  invocation, and when to use `toolWorkflow`/HTTP Request Tool instead.
+lastUpdated: '2026-07-02'
 ---
 
 # n8n Custom Code Tool

--- a/skills/using-n8n-mcp-skills/SKILL.md
+++ b/skills/using-n8n-mcp-skills/SKILL.md
@@ -1,6 +1,17 @@
 ---
 name: using-n8n-mcp-skills
-description: Use when building, editing, validating, testing, or debugging an n8n workflow through the n8n-mcp MCP server — designing a flow, configuring a node, writing an expression or Code node, wiring credentials, or fixing one that misbehaves. The entry-point skill for the n8n-mcp-skills pack: it routes you to the right specialist skill, gives working knowledge of every n8n-mcp tool from turn one, and states the rules that keep workflows from breaking in production. Always consult it first on any n8n, workflow, node, or automation task — even a quick one-off, and even when the user names no skill — because n8n's surface drifts between versions and the specialist skills prevent silent failures.
+description: >-
+  Use when building, editing, validating, testing, or debugging an n8n workflow
+  through the n8n-mcp MCP server — designing a flow, configuring a node, writing
+  an expression or Code node, wiring credentials, or fixing one that
+  misbehaves. The entry-point skill for the n8n-mcp-skills pack: it routes you
+  to the right specialist skill, gives working knowledge of every n8n-mcp tool
+  from turn one, and states the rules that keep workflows from breaking in
+  production. Always consult it first on any n8n, workflow, node, or automation
+  task — even a quick one-off, and even when the user names no skill — because
+  n8n's surface drifts between versions and the specialist skills prevent
+  silent failures.
+lastUpdated: '2026-07-02'
 ---
 
 # Using the n8n-mcp Skills


### PR DESCRIPTION
## Problem

The `description` fields in two `SKILL.md` files contain unquoted colon-space sequences (`: `) that YAML parsers interpret as nested key-value mappings, causing frontmatter parse failures:

| File | Trigger text |
|---|---|
| `skills/n8n-code-tool/SKILL.md` | `Code Tool: return format` |
| `skills/using-n8n-mcp-skills/SKILL.md` | `pack: it routes you` |

Verified with PyYAML:
```
BROKEN skills/n8n-code-tool/SKILL.md: mapping values are not allowed here
BROKEN skills/using-n8n-mcp-skills/SKILL.md: mapping values are not allowed here
```

## Fix

Switched both `description` values to YAML **folded block scalars** (`>-`), which safely handle colons, quotes, backticks, and apostrophes without any escaping. Added a `lastUpdated` field for traceability.

**Frontmatter-only change** — no body content is modified.

## Verification

After the fix, both files parse cleanly:
```
OK skills/n8n-code-tool/SKILL.md
  name: n8n-code-tool
  lastUpdated: 2026-07-02
  description length: 932 chars

OK skills/using-n8n-mcp-skills/SKILL.md
  name: using-n8n-mcp-skills
  lastUpdated: 2026-07-02
  description length: 694 chars
```

The other 13 skills in the pack are unaffected and already parse correctly.