### PR TITLE
docs: add TakoAPI directory badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # n8n-skills
 
+[![Listed on TakoAPI](https://takoapi.com/api/badge/czlonkowski-n8n-skills)](https://takoapi.com/agents/czlonkowski-n8n-skills)
+
 **Expert Claude Code skills for building flawless n8n workflows using the n8n-mcp MCP server**
 
 [![skills.sh](https://skills.sh/b/czlonkowski/n8n-skills)](https://skills.sh/czlonkowski/n8n-skills)


### PR DESCRIPTION
Hi! 👋 **n8n-skills** is listed in the [TakoAPI](https://takoapi.com) open agent directory — a free, open catalog that helps people discover AI-agent projects ("one API to discover all agents").

Your listing: https://takoapi.com/agents/czlonkowski-n8n-skills

This PR adds a small badge near the top of the README that links back to that listing, so visitors can find the directory entry. It's entirely optional — if you'd prefer not to include it, just close this PR (no hard feelings, and apologies for the noise).

No tracking and no obligations. Thanks for building n8n-skills! 🙏