### PR TITLE
fix(codex): avoid duplicate router injection while keeping tool hooks

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,41 @@
+{
+  "name": "n8n-mcp-skills",
+  "version": "1.25.0",
+  "description": "Expert skills for building n8n workflows with n8n-mcp, with tool-aware hooks for Codex",
+  "author": {
+    "name": "Romuald Członkowski",
+    "url": "https://www.aiadvisors.pl/en"
+  },
+  "homepage": "https://github.com/czlonkowski/n8n-skills",
+  "repository": "https://github.com/czlonkowski/n8n-skills",
+  "license": "MIT",
+  "keywords": [
+    "n8n",
+    "workflow",
+    "automation",
+    "mcp",
+    "validation",
+    "expressions",
+    "code",
+    "javascript",
+    "python"
+  ],
+  "skills": "./skills/",
+  "hooks": "./hooks/hooks-codex.json",
+  "interface": {
+    "displayName": "n8n MCP Skills",
+    "shortDescription": "Build reliable n8n workflows with n8n-mcp",
+    "longDescription": "Expert workflow, node configuration, validation, code, AI agent, error handling, and self-hosting guidance for n8n-mcp.",
+    "developerName": "Romuald Członkowski",
+    "category": "Developer Tools",
+    "capabilities": [
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://github.com/czlonkowski/n8n-skills",
+    "defaultPrompt": [
+      "Build and validate an n8n workflow.",
+      "Help me configure an n8n node correctly."
+    ]
+  }
+}

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.sh text eol=lf
+hooks/run-hook.cmd text eol=lf

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@ This is the **n8n-skills** repository - a collection of Claude Code skills desig
 n8n-skills/
 ├── README.md              # Project overview with video
 ├── LICENSE                # MIT License
+├── .codex-plugin/         # Codex manifest; selects hooks/hooks-codex.json
 ├── skills/                # Individual skill implementations
 │   ├── n8n-expression-syntax/
 │   ├── n8n-mcp-tools-expert/
@@ -36,16 +37,17 @@ n8n-skills/
 │   ├── n8n-agents/
 │   ├── n8n-multi-instance/
 │   ├── n8n-self-hosting/         # Deployment/ops skill (deploy n8n to a VM); not in the router/hooks flow
-│   └── using-n8n-mcp-skills/  # Always-on router skill (loaded by SessionStart hook)
-├── hooks/                 # Enforcement layer: hooks.json + SessionStart/PreToolUse/PostToolUse scripts
+│   └── using-n8n-mcp-skills/  # Router skill (SessionStart on Claude; native activation on Codex)
+├── hooks/                 # Platform hook configs + SessionStart/PreToolUse/PostToolUse scripts
 ├── evaluations/           # Test scenarios for each skill
+├── tests/                 # Dependency-free configuration checks
 ├── docs/                  # Documentation
 ├── dist/                  # Build output (gitignored — zips ship as GitHub Release assets, never committed; committed zips broke Desktop/Cowork plugin installs)
 ├── NOTICES                # Attribution for Apache-2.0 material adapted from n8n-io/skills
 └── .claude-plugin/        # Claude Code plugin configuration
 ```
 
-**Enforcement layer (hooks/):** the plugin ships hooks that surface the right skill at the moment of decision. `session-start.sh` injects the `using-n8n-mcp-skills` router every session; PreToolUse hooks fire node-specific reminders on `get_node`, one-shot reminders on create/update/validate/test, and one-shot multi-instance/credential reminders on `n8n_instances`/`n8n_manage_credentials`; the PostToolUse hook parses `validate_workflow`'s node JSON and routes to the relevant skills. Hooks run only in the Claude Code / Codex plugin install (not Claude.ai zip uploads), fail open, and never block a tool call. Attribution for the adapted scripts lives in `NOTICES` and the script headers — never inside agent-facing SKILL.md content.
+**Enforcement layer (hooks/):** the plugin ships hooks that surface the right skill at the moment of decision. Claude Code uses `hooks/hooks.json`, where `session-start.sh` injects the `using-n8n-mcp-skills` router every session. Codex uses `hooks/hooks-codex.json`, which intentionally omits `SessionStart` because Codex natively discovers and loads matching skills; injecting the complete router as well would duplicate it in context. Both platforms retain the tool-aware hooks: PreToolUse hooks fire node-specific reminders on `get_node`, one-shot reminders on create/update/validate/test, and one-shot multi-instance/credential reminders on `n8n_instances`/`n8n_manage_credentials`; the PostToolUse hook parses `validate_workflow`'s node JSON and routes to the relevant skills. Hooks run only in plugin installs (not Claude.ai zip uploads), fail open, and never block a tool call. Attribution for the adapted scripts lives in `NOTICES` and the script headers — never inside agent-facing SKILL.md content.
 
 ## The 14 Skills
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ n8n-skills/
 │   ├── n8n-multi-instance/
 │   ├── n8n-self-hosting/         # Deployment/ops skill (deploy n8n to a VM); not in the router/hooks flow
 │   └── using-n8n-mcp-skills/  # Router skill (SessionStart on Claude; native activation on Codex)
-├── hooks/                 # Platform hook configs + SessionStart/PreToolUse/PostToolUse scripts
+├── hooks/                 # Platform configs, cross-platform runner, and lifecycle hook scripts
 ├── evaluations/           # Test scenarios for each skill
 ├── tests/                 # Dependency-free configuration checks
 ├── docs/                  # Documentation
@@ -47,7 +47,7 @@ n8n-skills/
 └── .claude-plugin/        # Claude Code plugin configuration
 ```
 
-**Enforcement layer (hooks/):** the plugin ships hooks that surface the right skill at the moment of decision. Claude Code uses `hooks/hooks.json`, where `session-start.sh` injects the `using-n8n-mcp-skills` router every session. Codex uses `hooks/hooks-codex.json`, which intentionally omits `SessionStart` because Codex natively discovers and loads matching skills; injecting the complete router as well would duplicate it in context. Both platforms retain the tool-aware hooks: PreToolUse hooks fire node-specific reminders on `get_node`, one-shot reminders on create/update/validate/test, and one-shot multi-instance/credential reminders on `n8n_instances`/`n8n_manage_credentials`; the PostToolUse hook parses `validate_workflow`'s node JSON and routes to the relevant skills. Hooks run only in plugin installs (not Claude.ai zip uploads), fail open, and never block a tool call. Attribution for the adapted scripts lives in `NOTICES` and the script headers — never inside agent-facing SKILL.md content.
+**Enforcement layer (hooks/):** the plugin ships hooks that surface the right skill at the moment of decision. Claude Code uses `hooks/hooks.json`, where `session-start.sh` injects the `using-n8n-mcp-skills` router every session. Codex uses `hooks/hooks-codex.json`, which intentionally omits `SessionStart` because Codex natively discovers and loads matching skills; injecting the complete router as well would duplicate it in context. Both platforms retain the tool-aware hooks: PreToolUse hooks fire node-specific reminders on `get_node`, one-shot reminders on create/update/validate/test, and one-shot multi-instance/credential reminders on `n8n_instances`/`n8n_manage_credentials`; the PostToolUse hook parses `validate_workflow`'s node JSON and routes to the relevant skills. Codex runs those Bash scripts through `hooks/run-hook.cmd` so Windows uses Git Bash rather than opening `.sh` files through file association. Hooks run only in plugin installs (not Claude.ai zip uploads), fail open, and never block a tool call. Attribution for the adapted scripts lives in `NOTICES` and the script headers — never inside agent-facing SKILL.md content.
 
 ## The 14 Skills
 

--- a/README.md
+++ b/README.md
@@ -210,11 +210,11 @@ Deploy a production self-hosted n8n end-to-end to a fresh Linux VM.
 
 Beyond the capability skills, the plugin ships an **always-on enforcement layer** so the right guidance surfaces at the moment of decision — not only when a query happens to match a skill description.
 
-- **Router skill (`using-n8n-mcp-skills`)** — loaded into every session by a `SessionStart` hook. It routes you to the right skill, summarizes every n8n-mcp tool, and states the cross-cutting rules. It re-fires on resume/clear/compact so it survives context compaction.
+- **Router skill (`using-n8n-mcp-skills`)** — loaded into every Claude Code session by a `SessionStart` hook. It routes you to the right skill, summarizes every n8n-mcp tool, and states the cross-cutting rules. It re-fires on resume/clear/compact so it survives context compaction. Codex discovers and loads this skill natively, so its platform-specific hook configuration intentionally omits `SessionStart` to avoid injecting the full router twice.
 - **PreToolUse hooks** — before high-impact n8n-mcp calls, a short reminder points at the relevant skill. Looking up a Set, Code, Merge, Loop Over Items, DateTime, Data Table, or AI Agent node via `get_node` fires a node-specific reminder (and re-fires each time, because a re-lookup usually means you're reconsidering the same decision). Calls to `n8n_instances` and `n8n_manage_credentials` fire one-shot reminders pointing at the multi-instance and credential-discipline skills.
 - **PostToolUse hook** — after `validate_workflow`, it inspects the workflow's node types and routes you to the skills that own the remaining risks, with the reminder that *validation passing is necessary, not sufficient*.
 
-Hooks run only in the **Claude Code / Codex plugin** install. On Claude.ai (individual skill uploads) the skills still activate by description — the pack degrades gracefully, just without the proactive nudges. Every hook fails open and never blocks a tool call.
+Hooks run only in the **Claude Code / Codex plugin** install. Claude Code uses `hooks/hooks.json`, including the router-injection hook. Codex uses `hooks/hooks-codex.json`: it keeps the tool-aware `PreToolUse` and `PostToolUse` guards but omits the redundant skill-injection hook. On Claude.ai (individual skill uploads) the skills still activate by description — the pack degrades gracefully, just without the proactive nudges. Every hook fails open and never blocks a tool call.
 
 ---
 
@@ -223,7 +223,7 @@ Hooks run only in the **Claude Code / Codex plugin** install. On Claude.ai (indi
 ### Prerequisites
 
 1. **n8n-mcp MCP server** installed and configured ([Installation Guide](https://github.com/czlonkowski/n8n-mcp))
-2. **Claude Code**, Claude.ai, or Claude API access
+2. **Claude Code**, Codex, Claude.ai, or Claude API access
 3. `.mcp.json` configured with n8n-mcp server
 
 ### Claude Code
@@ -255,6 +255,20 @@ cp -r n8n-skills/skills/* ~/.claude/skills/
 # 3. Reload Claude Code
 # Skills will activate automatically
 ```
+
+### Codex
+
+Install the repository as a Codex marketplace and then install the plugin:
+
+```bash
+codex plugin marketplace add czlonkowski/n8n-skills --ref main
+codex plugin add n8n-mcp-skills@n8n-mcp-skills
+```
+
+Codex reads `.codex-plugin/plugin.json`, loads skills progressively, and uses
+`hooks/hooks-codex.json`. The Codex hook configuration deliberately excludes
+`SessionStart` skill injection while retaining the tool-aware `PreToolUse` and
+`PostToolUse` safeguards.
 
 ### Claude.ai
 

--- a/README.md
+++ b/README.md
@@ -268,7 +268,9 @@ codex plugin add n8n-mcp-skills@n8n-mcp-skills
 Codex reads `.codex-plugin/plugin.json`, loads skills progressively, and uses
 `hooks/hooks-codex.json`. The Codex hook configuration deliberately excludes
 `SessionStart` skill injection while retaining the tool-aware `PreToolUse` and
-`PostToolUse` safeguards.
+`PostToolUse` safeguards. Those Bash-based tool hooks run through
+`hooks/run-hook.cmd`, which locates Git Bash on Windows instead of asking the
+operating system to open a `.sh` file.
 
 ### Claude.ai
 

--- a/build.sh
+++ b/build.sh
@@ -43,10 +43,11 @@ for skill in "${SKILLS[@]}"; do
     (cd skills && zip -rq "../$DIST_DIR/${skill}-v${VERSION}.zip" "${skill}/" -x "*.DS_Store")
 done
 
-# Build complete bundle (for Claude Code)
-echo "📦 Building complete bundle for Claude Code..."
+# Build complete plugin bundle (for Claude Code and Codex)
+echo "📦 Building complete plugin bundle for Claude Code and Codex..."
 zip -rq "$DIST_DIR/n8n-mcp-skills-v${VERSION}.zip" \
     .claude-plugin/ \
+    .codex-plugin/ \
     hooks/ \
     README.md \
     LICENSE \

--- a/hooks/hooks-codex.json
+++ b/hooks/hooks-codex.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${PLUGIN_ROOT}/hooks/pre-tool-use/get-node.sh"
+            "command": "\"${PLUGIN_ROOT}/hooks/run-hook.cmd\" pre-tool-use/get-node.sh"
           }
         ]
       },
@@ -15,7 +15,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${PLUGIN_ROOT}/hooks/pre-tool-use/create-workflow.sh"
+            "command": "\"${PLUGIN_ROOT}/hooks/run-hook.cmd\" pre-tool-use/create-workflow.sh"
           }
         ]
       },
@@ -24,7 +24,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${PLUGIN_ROOT}/hooks/pre-tool-use/update-workflow.sh"
+            "command": "\"${PLUGIN_ROOT}/hooks/run-hook.cmd\" pre-tool-use/update-workflow.sh"
           }
         ]
       },
@@ -33,7 +33,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${PLUGIN_ROOT}/hooks/pre-tool-use/validate-workflow.sh"
+            "command": "\"${PLUGIN_ROOT}/hooks/run-hook.cmd\" pre-tool-use/validate-workflow.sh"
           }
         ]
       },
@@ -42,7 +42,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${PLUGIN_ROOT}/hooks/pre-tool-use/test-workflow.sh"
+            "command": "\"${PLUGIN_ROOT}/hooks/run-hook.cmd\" pre-tool-use/test-workflow.sh"
           }
         ]
       },
@@ -51,7 +51,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${PLUGIN_ROOT}/hooks/pre-tool-use/instances.sh"
+            "command": "\"${PLUGIN_ROOT}/hooks/run-hook.cmd\" pre-tool-use/instances.sh"
           }
         ]
       },
@@ -60,7 +60,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${PLUGIN_ROOT}/hooks/pre-tool-use/manage-credentials.sh"
+            "command": "\"${PLUGIN_ROOT}/hooks/run-hook.cmd\" pre-tool-use/manage-credentials.sh"
           }
         ]
       }
@@ -71,7 +71,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${PLUGIN_ROOT}/hooks/post-tool-use/validate-workflow.sh"
+            "command": "\"${PLUGIN_ROOT}/hooks/run-hook.cmd\" post-tool-use/validate-workflow.sh"
           }
         ]
       }

--- a/hooks/hooks-codex.json
+++ b/hooks/hooks-codex.json
@@ -1,0 +1,80 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "^mcp__.*__get_node$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${PLUGIN_ROOT}/hooks/pre-tool-use/get-node.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "^mcp__.*__n8n_create_workflow$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${PLUGIN_ROOT}/hooks/pre-tool-use/create-workflow.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "^mcp__.*__(n8n_update_partial_workflow|n8n_update_full_workflow)$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${PLUGIN_ROOT}/hooks/pre-tool-use/update-workflow.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "^mcp__.*__(validate_workflow|n8n_validate_workflow)$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${PLUGIN_ROOT}/hooks/pre-tool-use/validate-workflow.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "^mcp__.*__n8n_test_workflow$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${PLUGIN_ROOT}/hooks/pre-tool-use/test-workflow.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "^mcp__.*__n8n_instances$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${PLUGIN_ROOT}/hooks/pre-tool-use/instances.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "^mcp__.*__n8n_manage_credentials$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${PLUGIN_ROOT}/hooks/pre-tool-use/manage-credentials.sh"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "^mcp__.*__validate_workflow$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${PLUGIN_ROOT}/hooks/post-tool-use/validate-workflow.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/hooks/run-hook.cmd
+++ b/hooks/run-hook.cmd
@@ -1,0 +1,37 @@
+: << 'CMDBLOCK'
+@echo off
+REM Cross-platform launcher for the Bash-based n8n hook scripts.
+REM Usage: run-hook.cmd <script-path> [args...]
+
+if "%~1"=="" (
+    echo run-hook.cmd: missing script path >&2
+    exit /b 1
+)
+
+set "HOOK_DIR=%~dp0"
+
+if exist "C:\Program Files\Git\bin\bash.exe" (
+    "C:\Program Files\Git\bin\bash.exe" "%HOOK_DIR%%~1" %2 %3 %4 %5 %6 %7 %8 %9
+    exit /b %ERRORLEVEL%
+)
+
+if exist "C:\Program Files (x86)\Git\bin\bash.exe" (
+    "C:\Program Files (x86)\Git\bin\bash.exe" "%HOOK_DIR%%~1" %2 %3 %4 %5 %6 %7 %8 %9
+    exit /b %ERRORLEVEL%
+)
+
+where bash >nul 2>nul
+if %ERRORLEVEL% equ 0 (
+    bash "%HOOK_DIR%%~1" %2 %3 %4 %5 %6 %7 %8 %9
+    exit /b %ERRORLEVEL%
+)
+
+REM Fail open if Bash is unavailable so a hook never blocks the MCP tool.
+exit /b 0
+CMDBLOCK
+
+# Unix: execute the requested hook through Bash.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_NAME="$1"
+shift
+exec bash "${SCRIPT_DIR}/${SCRIPT_NAME}" "$@"

--- a/tests/validate_hook_configs.py
+++ b/tests/validate_hook_configs.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Validate the platform-specific hook split without external dependencies."""
+
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_json(relative_path: str) -> dict:
+    with (ROOT / relative_path).open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def normalized_tool_hooks(config: dict) -> dict:
+    """Normalize platform-specific plugin-root environment variables."""
+    serialized = json.dumps(config)
+    serialized = serialized.replace("${CLAUDE_PLUGIN_ROOT}", "${PLUGIN_ROOT}")
+    return json.loads(serialized)
+
+
+def main() -> None:
+    claude = load_json("hooks/hooks.json")["hooks"]
+    codex = load_json("hooks/hooks-codex.json")["hooks"]
+    manifest = load_json(".codex-plugin/plugin.json")
+
+    assert "SessionStart" in claude
+    assert "SessionStart" not in codex
+    assert set(codex) == {"PreToolUse", "PostToolUse"}
+
+    for event in ("PreToolUse", "PostToolUse"):
+        assert normalized_tool_hooks(claude[event]) == codex[event]
+
+    assert manifest["skills"] == "./skills/"
+    assert manifest["hooks"] == "./hooks/hooks-codex.json"
+
+    for event_entries in codex.values():
+        for entry in event_entries:
+            for hook in entry["hooks"]:
+                relative_command = hook["command"].replace("${PLUGIN_ROOT}/", "")
+                assert (ROOT / relative_command).is_file(), relative_command
+
+    print("Hook configuration split is valid.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/validate_hook_configs.py
+++ b/tests/validate_hook_configs.py
@@ -2,10 +2,14 @@
 """Validate the platform-specific hook split without external dependencies."""
 
 import json
+import os
 from pathlib import Path
+import subprocess
+import uuid
 
 
 ROOT = Path(__file__).resolve().parents[1]
+CODEX_RUNNER_PREFIX = '"${PLUGIN_ROOT}/hooks/run-hook.cmd" '
 
 
 def load_json(relative_path: str) -> dict:
@@ -15,9 +19,40 @@ def load_json(relative_path: str) -> dict:
 
 def normalized_tool_hooks(config: dict) -> dict:
     """Normalize platform-specific plugin-root environment variables."""
-    serialized = json.dumps(config)
-    serialized = serialized.replace("${CLAUDE_PLUGIN_ROOT}", "${PLUGIN_ROOT}")
-    return json.loads(serialized)
+    normalized = json.loads(json.dumps(config))
+    for entry in normalized:
+        for hook in entry["hooks"]:
+            command = hook["command"]
+            if command.startswith(CODEX_RUNNER_PREFIX):
+                command = "${PLUGIN_ROOT}/hooks/" + command[len(CODEX_RUNNER_PREFIX) :]
+            hook["command"] = command.replace(
+                "${CLAUDE_PLUGIN_ROOT}",
+                "${PLUGIN_ROOT}",
+            )
+    return normalized
+
+
+def verify_codex_runner() -> None:
+    runner = ROOT / "hooks" / "run-hook.cmd"
+    assert runner.is_file(), "Codex hook runner is missing"
+
+    session_id = f"hook-runner-test-{uuid.uuid4()}"
+    if os.name == "nt":
+        command = ["cmd.exe", "/d", "/c", str(runner)]
+    else:
+        command = ["bash", str(runner)]
+
+    result = subprocess.run(
+        command
+        + ["pre-tool-use/_emit.sh", "runner-test", "runner works"],
+        input=json.dumps({"session_id": session_id}),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["hookSpecificOutput"]["additionalContext"] == "runner works"
 
 
 def main() -> None:
@@ -30,7 +65,7 @@ def main() -> None:
     assert set(codex) == {"PreToolUse", "PostToolUse"}
 
     for event in ("PreToolUse", "PostToolUse"):
-        assert normalized_tool_hooks(claude[event]) == codex[event]
+        assert normalized_tool_hooks(claude[event]) == normalized_tool_hooks(codex[event])
 
     assert manifest["skills"] == "./skills/"
     assert manifest["hooks"] == "./hooks/hooks-codex.json"
@@ -38,8 +73,11 @@ def main() -> None:
     for event_entries in codex.values():
         for entry in event_entries:
             for hook in entry["hooks"]:
-                relative_command = hook["command"].replace("${PLUGIN_ROOT}/", "")
-                assert (ROOT / relative_command).is_file(), relative_command
+                assert hook["command"].startswith(CODEX_RUNNER_PREFIX)
+                relative_command = hook["command"][len(CODEX_RUNNER_PREFIX) :]
+                assert (ROOT / "hooks" / relative_command).is_file(), relative_command
+
+    verify_codex_runner()
 
     print("Hook configuration split is valid.")
 


### PR DESCRIPTION
## Summary

- add a native `.codex-plugin/plugin.json`
- route Codex to `hooks/hooks-codex.json`
- omit only the `SessionStart` full-router injection on Codex
- retain all seven `PreToolUse` entries and the `PostToolUse` workflow-analysis hook
- run Codex's Bash-based tool hooks through a cross-platform `hooks/run-hook.cmd`
- leave Claude Code's existing `hooks/hooks.json` behavior unchanged
- include the Codex manifest and runner in release bundles
- add dependency-free regression coverage for the platform split and real runner execution

## Root cause

The legacy plugin has no `.codex-plugin/plugin.json`, so Codex falls back to auto-discovering the shared `hooks/hooks.json`. That file contains `SessionStart`, which invokes `session-start.sh` at every conversation start. Besides duplicating the router skill, invoking a `.sh` file directly on Windows can open it through the operating-system file association instead of executing it.

The initial Codex-specific configuration removed `SessionStart`, but its remaining tool hooks still invoked `.sh` files directly. This update closes that Windows gap: every Codex `PreToolUse` and `PostToolUse` command now enters through `run-hook.cmd`, which locates Git for Windows Bash (or Bash on PATH). Unix uses the same polyglot runner through Bash.

## Why the tool hooks remain

Current Codex uses progressive skill disclosure and loads matching `SKILL.md` files natively, so full-router injection is redundant. The tool-aware hooks are different: they react to concrete MCP tool names and payloads, and therefore remain useful.

This follows the narrower form of the approach used by `obra/superpowers`: remove redundant Codex skill injection without blanket-disabling tool-time enforcement.

## Validation

- regression test observed failing while Codex commands invoked `.sh` directly
- `python tests/validate_hook_configs.py` passes after the fix
- the test executes `run-hook.cmd` through `cmd.exe`, pipes hook JSON over stdin, and validates returned JSON
- all 15 skill directories pass `quick_validate.py`
- all Bash hook scripts and the polyglot runner pass `bash -n`
- `bash build.sh` produces 15 individual skill archives plus one complete plugin bundle
- all 16 ZIP files pass archive integrity checks
- the complete bundle contains both platform hook configs, the Codex manifest, and the cross-platform runner

Closes #41