### PR TITLE
fix(n8n-error-handling): correct updateNode and patchNodeField operation shapes

### DIFF
--- a/skills/n8n-error-handling/API_WORKFLOWS.md
+++ b/skills/n8n-error-handling/API_WORKFLOWS.md
@@ -34,8 +34,8 @@ A two-node processing chain, both fallible, both routing to one responder:
 
 ```javascript
 // Turn on error outputs
-{ type: "updateNode", nodeName: "Fetch User",    changes: { onError: "continueErrorOutput" } }
-{ type: "updateNode", nodeName: "Call External", changes: { onError: "continueErrorOutput" } }
+{ type: "updateNode", nodeName: "Fetch User",    updates: { onError: "continueErrorOutput" } }
+{ type: "updateNode", nodeName: "Call External", updates: { onError: "continueErrorOutput" } }
 
 // Success path
 { type: "addConnection", source: "Webhook",      target: "Fetch User",      sourceIndex: 0 }

--- a/skills/n8n-error-handling/NODE_ERROR_OUTPUTS.md
+++ b/skills/n8n-error-handling/NODE_ERROR_OUTPUTS.md
@@ -16,15 +16,16 @@ Set `onError: "continueErrorOutput"` on the node. This is what *adds* the second
 
 ```javascript
 { type: "updateNode", nodeName: "Google Sheets",
-  changes: { onError: "continueErrorOutput" } }
+  updates: { onError: "continueErrorOutput" } }
 ```
 
-Surgical alternative if you're touching only this field:
-
-```javascript
-{ type: "patchNodeField", nodeName: "Google Sheets",
-  fieldPath: "onError", value: "continueErrorOutput" }
-```
+**Do not reach for `patchNodeField` here.** It is a find/replace on an existing
+string field, not a setter: it takes `patches: [{find, replace}]`, and it errors
+with `property does not exist on node` when the field isn't set yet. A node whose
+error output you are switching on has no `onError` — that's the whole point — so
+the op fails in exactly the case you'd want it. `updateNode` above is the way to
+set a scalar node field; save `patchNodeField` for editing strings that already
+exist (Code node bodies, HTML, JSON payloads).
 
 The valid `onError` values:
 

--- a/skills/n8n-error-handling/README.md
+++ b/skills/n8n-error-handling/README.md
@@ -108,7 +108,7 @@ The workflow-level catch-all.
 ```javascript
 // 1) create the error output
 { type: "updateNode", nodeName: "HTTP Request",
-  changes: { onError: "continueErrorOutput" } }
+  updates: { onError: "continueErrorOutput" } }
 
 // 2) wire it (sourceIndex 1 = error output)
 { type: "addConnection", source: "HTTP Request", target: "Handle Error", sourceIndex: 1 }
@@ -117,7 +117,7 @@ The workflow-level catch-all.
 ### Self-healing on network nodes
 ```javascript
 { type: "updateNode", nodeName: "HTTP Request",
-  changes: { retryOnFail: true, maxTries: 3, waitBetweenTries: 5000 } }
+  updates: { retryOnFail: true, maxTries: 3, waitBetweenTries: 5000 } }
 ```
 
 ### Set the status code on an error Respond (don't leave it 200)

--- a/skills/n8n-error-handling/SKILL.md
+++ b/skills/n8n-error-handling/SKILL.md
@@ -48,7 +48,7 @@ Get one without the other and you hit a failure mode:
 ```javascript
 // 1) Turn on the error output (creates main[1])
 { type: "updateNode", nodeName: "HTTP Request",
-  changes: { onError: "continueErrorOutput" } }
+  updates: { onError: "continueErrorOutput" } }
 
 // 2) Wire the error output to a handler. sourceIndex: 1 = the error output.
 { type: "addConnection",
@@ -82,7 +82,7 @@ Before you build error branches, absorb the transient failures so they never rea
 
 ```javascript
 { type: "updateNode", nodeName: "HTTP Request",
-  changes: {
+  updates: {
     retryOnFail: true,
     maxTries: 3,
     waitBetweenTries: 5000   // ms


### PR DESCRIPTION
## What's wrong

The `n8n-error-handling` skill documents two `n8n_update_partial_workflow` operations
with shapes the tool rejects. Both fail on the first call, so anyone following the skill
hits an error before anything is applied.

### 1. `updateNode` takes `updates:`, not `changes:` (7 occurrences)

```
Missing required parameter 'updates'. The updateNode operation requires an 'updates'
object. Correct structure: {type: "updateNode", nodeId: "abc-123" OR nodeName: "My Node",
updates: {name: "New Name", "parameters.url": "https://example.com"}}
```

Affected lines:

| File | Lines |
|---|---|
| `SKILL.md` | 51, 85 |
| `README.md` | 111, 120 |
| `NODE_ERROR_OUTPUTS.md` | 19 |
| `API_WORKFLOWS.md` | 37, 38 |

This is confined to `n8n-error-handling` — no other skill in the pack uses `changes:`.

### 2. The `patchNodeField` "surgical alternative" cannot work (`NODE_ERROR_OUTPUTS.md`)

`NODE_ERROR_OUTPUTS.md` currently offers this as a lighter-weight way to set `onError`:

```javascript
{ type: "patchNodeField", nodeName: "Google Sheets",
  fieldPath: "onError", value: "continueErrorOutput" }
```

Two problems, and the second one is not fixable by renaming a parameter.

The signature is wrong — `patchNodeField` takes `patches: [{find, replace}]`:

```
patchNodeField requires a non-empty "patches" array of {find, replace} objects
```

And with the correct signature it still fails, because `patchNodeField` is a
find/replace on an existing string field rather than a setter:

```
Cannot apply patchNodeField to "onError": property does not exist on node "..."
```

A node whose error output you are switching on has no `onError` yet — that is the
premise of the surrounding section — so the operation fails in exactly the case it is
recommended for. Every other skill in the pack already describes `patchNodeField`
correctly as find/replace on code, HTML and JSON bodies; only this one presents it as a
scalar setter.

I replaced the block with a short note on why `updateNode` is the right tool here and
what `patchNodeField` is actually for, rather than just fixing the parameter name.

## Verification

Each corrected shape was checked against a live n8n instance with
`validateOnly: true`, so nothing was applied:

- `{type: "updateNode", nodeName: "...", updates: {onError: "continueErrorOutput"}}` → valid
- `{type: "updateNode", nodeName: "...", updates: {retryOnFail: true, maxTries: 3, waitBetweenTries: 5000}}` → valid
- `{type: "addConnection", source: "...", target: "...", sourceIndex: 1}` → valid

The two error messages quoted above are verbatim tool output from the same instance.

Found while wiring `retryOnFail` onto the write nodes of a production offboarding
workflow — the first `updateNode` call failed, which is what sent me looking.

Docs only; no behavior changes.
