### PR TITLE
Make hooks fire on Grok MCP tool names

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ n8n-skills/
 └── .claude-plugin/        # Claude Code plugin configuration
 ```
 
-**Enforcement layer (hooks/):** the plugin ships hooks that surface the right skill at the moment of decision. `session-start.sh` injects the `using-n8n-mcp-skills` router every session; PreToolUse hooks fire node-specific reminders on `get_node`, one-shot reminders on create/update/validate/test, and one-shot multi-instance/credential reminders on `n8n_instances`/`n8n_manage_credentials`; the PostToolUse hook parses `validate_workflow`'s node JSON and routes to the relevant skills. Hooks run only in the Claude Code / Codex plugin install (not Claude.ai zip uploads), fail open, and never block a tool call. Attribution for the adapted scripts lives in `NOTICES` and the script headers — never inside agent-facing SKILL.md content.
+**Enforcement layer (hooks/):** the plugin ships hooks that surface the right skill at the moment of decision. `session-start.sh` injects the `using-n8n-mcp-skills` router every session; PreToolUse hooks fire node-specific reminders on `get_node`, one-shot reminders on create/update/validate/test, and one-shot multi-instance/credential reminders on `n8n_instances`/`n8n_manage_credentials`; the PostToolUse hook parses `validate_workflow`'s node JSON and routes to the relevant skills. Hooks run in the Claude Code / Codex / Grok plugin install (not Claude.ai zip uploads), fail open, and never block a tool call. Attribution for the adapted scripts lives in `NOTICES` and the script headers — never inside agent-facing SKILL.md content.
 
 ## The 14 Skills
 
@@ -202,7 +202,7 @@ Skills are designed to work together:
 ## Requirements
 
 - n8n-mcp MCP server installed and configured
-- Claude Code, Claude.ai, or Claude API access
+- Claude Code, Claude.ai, Claude API, or Grok access
 - Understanding of n8n workflow concepts
 
 ## Distribution

--- a/README.md
+++ b/README.md
@@ -214,7 +214,9 @@ Beyond the capability skills, the plugin ships an **always-on enforcement layer*
 - **PreToolUse hooks** — before high-impact n8n-mcp calls, a short reminder points at the relevant skill. Looking up a Set, Code, Merge, Loop Over Items, DateTime, Data Table, or AI Agent node via `get_node` fires a node-specific reminder (and re-fires each time, because a re-lookup usually means you're reconsidering the same decision). Calls to `n8n_instances` and `n8n_manage_credentials` fire one-shot reminders pointing at the multi-instance and credential-discipline skills.
 - **PostToolUse hook** — after `validate_workflow`, it inspects the workflow's node types and routes you to the skills that own the remaining risks, with the reminder that *validation passing is necessary, not sufficient*.
 
-Hooks run only in the **Claude Code / Codex plugin** install. On Claude.ai (individual skill uploads) the skills still activate by description — the pack degrades gracefully, just without the proactive nudges. Every hook fails open and never blocks a tool call.
+Hooks run in the **Claude Code / Codex / Grok** plugin install. On Claude.ai (individual skill uploads) the skills still activate by description — the pack degrades gracefully, just without the proactive nudges. Every hook fails open and never blocks a tool call.
+
+Matchers accept both Claude Code's `mcp__<server>__<tool>` names and Grok's `<server>__<tool>` names. Hook scripts read Claude's `session_id` / `tool_input` and Grok's `sessionId` / `toolInput`.
 
 ---
 
@@ -223,7 +225,7 @@ Hooks run only in the **Claude Code / Codex plugin** install. On Claude.ai (indi
 ### Prerequisites
 
 1. **n8n-mcp MCP server** installed and configured ([Installation Guide](https://github.com/czlonkowski/n8n-mcp))
-2. **Claude Code**, Claude.ai, or Claude API access
+2. **Claude Code**, Claude.ai, Claude API, or [Grok](https://grok.x.ai) access
 3. `.mcp.json` configured with n8n-mcp server
 
 ### Claude Code
@@ -255,6 +257,15 @@ cp -r n8n-skills/skills/* ~/.claude/skills/
 # 3. Reload Claude Code
 # Skills will activate automatically
 ```
+
+### Grok
+
+```bash
+grok plugin marketplace add czlonkowski/n8n-skills
+grok plugin install n8n-mcp-skills --trust
+```
+
+Install from a local checkout with `grok plugin install /path/to/n8n-skills --trust`. Start a new session afterward; `grok inspect` should list the 15 skills as `plugin: n8n-mcp-skills`.
 
 ### Claude.ai
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -36,12 +36,13 @@ npm install -g n8n-mcp
 
 **Note**: `N8N_API_URL` and `N8N_API_KEY` are optional but enable workflow creation/management tools.
 
-### 2. Claude Access
+### 2. Agent access
 
 You need one of:
 - **Claude Code** (desktop application)
 - **Claude.ai** (web interface)
 - **Claude API** (via SDK)
+- **[Grok](https://grok.x.ai)** (plugin install; hooks fire in this client)
 
 ---
 
@@ -167,7 +168,20 @@ function loadSkillsFromDirectory(dir: string) {
 
 ---
 
-### Method 4: Other Agents and IDEs (Antigravity, etc.)
+### Method 4: Grok
+
+Plugin install (recommended). Hooks fire in this client.
+
+```bash
+grok plugin marketplace add czlonkowski/n8n-skills
+grok plugin install n8n-mcp-skills --trust
+```
+
+Install from a local checkout with `grok plugin install /path/to/n8n-skills --trust`. Start a new session afterward; `grok inspect` should list the 15 skills as `plugin: n8n-mcp-skills` and report that the plugin provides hooks.
+
+---
+
+### Method 5: Other Agents and IDEs (Antigravity, etc.)
 
 Agent Skills are an open standard — any agent that supports the SKILL.md format can use these skills, not just Claude.
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -13,7 +13,7 @@
     ],
     "PreToolUse": [
       {
-        "matcher": "^mcp__.*__get_node$",
+        "matcher": "(^|__)get_node$",
         "hooks": [
           {
             "type": "command",
@@ -22,7 +22,7 @@
         ]
       },
       {
-        "matcher": "^mcp__.*__n8n_create_workflow$",
+        "matcher": "(^|__)n8n_create_workflow$",
         "hooks": [
           {
             "type": "command",
@@ -31,7 +31,7 @@
         ]
       },
       {
-        "matcher": "^mcp__.*__(n8n_update_partial_workflow|n8n_update_full_workflow)$",
+        "matcher": "(^|__)(n8n_update_partial_workflow|n8n_update_full_workflow)$",
         "hooks": [
           {
             "type": "command",
@@ -40,7 +40,7 @@
         ]
       },
       {
-        "matcher": "^mcp__.*__(validate_workflow|n8n_validate_workflow)$",
+        "matcher": "(^|__)(validate_workflow|n8n_validate_workflow)$",
         "hooks": [
           {
             "type": "command",
@@ -49,7 +49,7 @@
         ]
       },
       {
-        "matcher": "^mcp__.*__n8n_test_workflow$",
+        "matcher": "(^|__)n8n_test_workflow$",
         "hooks": [
           {
             "type": "command",
@@ -58,7 +58,7 @@
         ]
       },
       {
-        "matcher": "^mcp__.*__n8n_instances$",
+        "matcher": "(^|__)n8n_instances$",
         "hooks": [
           {
             "type": "command",
@@ -67,7 +67,7 @@
         ]
       },
       {
-        "matcher": "^mcp__.*__n8n_manage_credentials$",
+        "matcher": "(^|__)n8n_manage_credentials$",
         "hooks": [
           {
             "type": "command",
@@ -78,7 +78,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "^mcp__.*__validate_workflow$",
+        "matcher": "(^|__)validate_workflow$",
         "hooks": [
           {
             "type": "command",

--- a/hooks/post-tool-use/validate-workflow.sh
+++ b/hooks/post-tool-use/validate-workflow.sh
@@ -6,7 +6,8 @@
 # Fires AFTER validate_workflow. Validation passing is necessary, not sufficient.
 #
 # n8n-mcp's validate_workflow takes the FULL workflow JSON, so we parse the node
-# types out of .tool_input.workflow.nodes[].type (LONG form, e.g.
+# types out of .tool_input.workflow.nodes[].type (Claude) or
+# .toolInput.workflow.nodes[].type (Grok) — LONG form, e.g.
 # "n8n-nodes-base.set") and route to the relevant skills. This is more robust
 # than grepping source code. Fires every call (no dedup).
 #
@@ -21,7 +22,7 @@ INPUT="$(cat)"
 # Node types from the validated workflow JSON. Fall back to a flattened nodes
 # array in case a server nests differently.
 NODE_TYPES="$(echo "${INPUT}" | jq -r '
-  (.tool_input.workflow.nodes // .tool_input.nodes // [])
+  (.tool_input.workflow.nodes // .toolInput.workflow.nodes // .tool_input.nodes // .toolInput.nodes // [])
   | map(.type // empty) | .[]
 ' 2>/dev/null)"
 

--- a/hooks/pre-tool-use/_emit.sh
+++ b/hooks/pre-tool-use/_emit.sh
@@ -4,9 +4,9 @@
 # Adapted for the community n8n-mcp MCP server. See /NOTICES.
 #
 # Shared helper for PreToolUse hooks.
-# Reads the session_id from stdin (Claude Code hook input is JSON), checks for
-# a per-session marker file, and emits a one-shot reminder telling Claude to
-# invoke the relevant Skill via the Skill tool.
+# Reads the session id from stdin (Claude Code: session_id; Grok: sessionId),
+# checks for a per-session marker file, and emits a one-shot reminder telling
+# the agent to invoke the relevant Skill.
 #
 # Usage: _emit.sh <marker-name> <reminder-text>
 #
@@ -26,13 +26,13 @@ if [[ -z "${MARKER_NAME}" || -z "${REMINDER}" ]]; then
   exit 0
 fi
 
-# Read session_id from the hook input JSON on stdin.
+# Read session id from the hook input JSON on stdin.
 INPUT="$(cat)"
 
 if command -v jq >/dev/null 2>&1; then
-  SESSION_ID="$(echo "${INPUT}" | jq -r '.session_id // empty' 2>/dev/null)"
+  SESSION_ID="$(echo "${INPUT}" | jq -r '.session_id // .sessionId // empty' 2>/dev/null)"
 elif command -v python3 >/dev/null 2>&1; then
-  SESSION_ID="$(echo "${INPUT}" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("session_id",""))' 2>/dev/null)"
+  SESSION_ID="$(echo "${INPUT}" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("session_id") or d.get("sessionId") or "")' 2>/dev/null)"
 else
   exit 0
 fi

--- a/hooks/pre-tool-use/get-node.sh
+++ b/hooks/pre-tool-use/get-node.sh
@@ -14,8 +14,8 @@
 #    decision after the first.
 #
 # n8n-mcp's get_node takes a single SHORT-form node type, e.g. nodes-base.set or
-# nodes-langchain.agent, in .tool_input.nodeType (not an array like the official
-# get_node_types). The anchored regexes below match the short form.
+# nodes-langchain.agent, in .tool_input.nodeType (Claude) or .toolInput.nodeType
+# (Grok). The anchored regexes below match the short form.
 
 set -uo pipefail
 
@@ -25,10 +25,10 @@ if ! command -v jq >/dev/null 2>&1; then
   exit 0
 fi
 
-SESSION_ID="$(echo "${INPUT}" | jq -r '.session_id // empty' 2>/dev/null)"
+SESSION_ID="$(echo "${INPUT}" | jq -r '.session_id // .sessionId // empty' 2>/dev/null)"
 [ -z "${SESSION_ID}" ] && exit 0
 
-NODE_TYPE="$(echo "${INPUT}" | jq -r '.tool_input.nodeType // empty' 2>/dev/null)"
+NODE_TYPE="$(echo "${INPUT}" | jq -r '.tool_input.nodeType // .toolInput.nodeType // empty' 2>/dev/null)"
 
 STATE_DIR="${TMPDIR:-/tmp}/n8n-mcp-skills-state"
 mkdir -p "${STATE_DIR}" 2>/dev/null || exit 0

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -32,7 +32,7 @@ INPUT="$(cat)"
 
 if command -v jq >/dev/null 2>&1; then
   SOURCE="$(echo "${INPUT}" | jq -r '.source // empty' 2>/dev/null)"
-  SESSION_ID="$(echo "${INPUT}" | jq -r '.session_id // empty' 2>/dev/null)"
+  SESSION_ID="$(echo "${INPUT}" | jq -r '.session_id // .sessionId // empty' 2>/dev/null)"
 
   if [[ "${SOURCE}" == "clear" || "${SOURCE}" == "compact" ]] && [[ -n "${SESSION_ID}" ]]; then
     STATE_DIR="${TMPDIR:-/tmp}/n8n-mcp-skills-state"

--- a/hooks/tests/test_e2e_grok_plugin.py
+++ b/hooks/tests/test_e2e_grok_plugin.py
@@ -52,10 +52,24 @@ class GrokPluginE2E(unittest.TestCase):
         self.assertIn("n8n-mcp-skills", plugins)
         self.assertTrue(plugins["n8n-mcp-skills"].get("enabled"))
 
+    def test_plugin_provides_hooks(self) -> None:
+        plugins = {p.get("name"): p for p in self.report.get("plugins") or []}
+        provides = (plugins.get("n8n-mcp-skills") or {}).get("provides") or {}
+        self.assertTrue(provides.get("hooks"), "n8n-mcp-skills plugin did not advertise hooks")
+        sourced = {
+            (h.get("source") or {}).get("plugin_name")
+            for h in (self.report.get("hooks") or [])
+        }
+        self.assertIn(
+            "n8n-mcp-skills",
+            sourced,
+            "grok inspect listed no hooks sourced from n8n-mcp-skills",
+        )
+
     def test_fifteen_skills_are_in_the_catalog(self) -> None:
         names = {s.get("name") for s in self.report.get("skills") or []}
         missing = REQUIRED_SKILLS - names
-        self.assertFalse(missing, f"skills discovered by the plugin but not in catalog: {sorted(missing)}")
+        self.assertFalse(missing, f"required skills missing from catalog: {sorted(missing)}")
 
     def test_skills_are_attributed_to_the_plugin(self) -> None:
         attributed = {
@@ -65,7 +79,7 @@ class GrokPluginE2E(unittest.TestCase):
             or (s.get("source") or {}).get("plugin_name") == "n8n-mcp-skills"
         }
         missing = REQUIRED_SKILLS - attributed
-        self.assertFalse(missing, f"skills present but not sourced from n8n-mcp-skills: {sorted(missing)}")
+        self.assertFalse(missing, f"required skills not sourced from n8n-mcp-skills: {sorted(missing)}")
 
 
 if __name__ == "__main__":

--- a/hooks/tests/test_e2e_grok_plugin.py
+++ b/hooks/tests/test_e2e_grok_plugin.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""End-to-end: an installed Grok plugin must expose the n8n-mcp-skills catalog."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import unittest
+
+REQUIRED_SKILLS = {
+    "using-n8n-mcp-skills",
+    "n8n-mcp-tools-expert",
+    "n8n-expression-syntax",
+    "n8n-workflow-patterns",
+    "n8n-validation-expert",
+    "n8n-node-configuration",
+    "n8n-code-javascript",
+    "n8n-code-python",
+    "n8n-code-tool",
+    "n8n-error-handling",
+    "n8n-binary-and-data",
+    "n8n-subworkflows",
+    "n8n-agents",
+    "n8n-multi-instance",
+    "n8n-self-hosting",
+}
+
+
+def inspect() -> dict:
+    grok = shutil.which("grok")
+    if grok is None:
+        raise unittest.SkipTest("grok CLI is not on PATH")
+    result = subprocess.run(
+        [grok, "inspect", "--json"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise AssertionError(f"grok inspect failed: {result.stderr or result.stdout}")
+    return json.loads(result.stdout)
+
+
+class GrokPluginE2E(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.report = inspect()
+
+    def test_plugin_is_enabled(self) -> None:
+        plugins = {p.get("name"): p for p in self.report.get("plugins") or []}
+        self.assertIn("n8n-mcp-skills", plugins)
+        self.assertTrue(plugins["n8n-mcp-skills"].get("enabled"))
+
+    def test_fifteen_skills_are_in_the_catalog(self) -> None:
+        names = {s.get("name") for s in self.report.get("skills") or []}
+        missing = REQUIRED_SKILLS - names
+        self.assertFalse(missing, f"skills discovered by the plugin but not in catalog: {sorted(missing)}")
+
+    def test_skills_are_attributed_to_the_plugin(self) -> None:
+        attributed = {
+            s.get("name")
+            for s in self.report.get("skills") or []
+            if s.get("plugin") == "n8n-mcp-skills"
+            or (s.get("source") or {}).get("plugin_name") == "n8n-mcp-skills"
+        }
+        missing = REQUIRED_SKILLS - attributed
+        self.assertFalse(missing, f"skills present but not sourced from n8n-mcp-skills: {sorted(missing)}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/hooks/tests/test_harness_compat.py
+++ b/hooks/tests/test_harness_compat.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""Hook harness compatibility: Claude snake_case + mcp__ vs Grok camelCase + server__tool."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import tempfile
+import unittest
+import uuid
+from pathlib import Path
+
+HOOKS_DIR = Path(__file__).resolve().parent.parent
+PLUGIN_ROOT = HOOKS_DIR.parent
+HOOKS_JSON = HOOKS_DIR / "hooks.json"
+EMIT = HOOKS_DIR / "pre-tool-use" / "_emit.sh"
+GET_NODE = HOOKS_DIR / "pre-tool-use" / "get-node.sh"
+SESSION_START = HOOKS_DIR / "session-start.sh"
+POST_VALIDATE = HOOKS_DIR / "post-tool-use" / "validate-workflow.sh"
+
+
+def run_script(script: Path, payload: dict, extra_args: list[str] | None = None, tmpdir: str | None = None) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["CLAUDE_PLUGIN_ROOT"] = str(PLUGIN_ROOT)
+    if tmpdir:
+        env["TMPDIR"] = tmpdir
+    return subprocess.run(
+        ["bash", str(script), *(extra_args or [])],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=str(PLUGIN_ROOT),
+        check=False,
+    )
+
+
+def context_text(stdout: str) -> str:
+    stdout = stdout.strip()
+    if not stdout:
+        return ""
+    data = json.loads(stdout)
+    return data.get("hookSpecificOutput", {}).get("additionalContext", "")
+
+
+def matchers_for(event: str) -> list[str]:
+    spec = json.loads(HOOKS_JSON.read_text())
+    return [block["matcher"] for block in spec["hooks"][event]]
+
+
+def any_match(event: str, tool_name: str) -> bool:
+    return any(re.search(pattern, tool_name) for pattern in matchers_for(event))
+
+
+class MatcherTests(unittest.TestCase):
+    """PreToolUse matchers must fire for Claude mcp__ names and Grok server__tool names."""
+
+    CLAUDE = {
+        "get_node": "mcp__n8n-mcp__get_node",
+        "create": "mcp__n8n-mcp__n8n_create_workflow",
+        "update_partial": "mcp__n8n-mcp__n8n_update_partial_workflow",
+        "update_full": "mcp__n8n-mcp__n8n_update_full_workflow",
+        "validate": "mcp__n8n-mcp__validate_workflow",
+        "n8n_validate": "mcp__n8n-mcp__n8n_validate_workflow",
+        "test": "mcp__n8n-mcp__n8n_test_workflow",
+        "instances": "mcp__n8n-mcp__n8n_instances",
+        "credentials": "mcp__n8n-mcp__n8n_manage_credentials",
+    }
+    GROK = {
+        "get_node": "n8n-mcp__get_node",
+        "create": "n8n-mcp__n8n_create_workflow",
+        "update_partial": "n8n-mcp__n8n_update_partial_workflow",
+        "update_full": "n8n-mcp__n8n_update_full_workflow",
+        "validate": "n8n-mcp__validate_workflow",
+        "n8n_validate": "n8n-mcp__n8n_validate_workflow",
+        "test": "n8n-mcp__n8n_test_workflow",
+        "instances": "n8n-mcp__n8n_instances",
+        "credentials": "n8n-mcp__n8n_manage_credentials",
+    }
+
+    def test_claude_mcp_names_still_match_pretooluse(self) -> None:
+        for name in self.CLAUDE.values():
+            self.assertTrue(any_match("PreToolUse", name), msg=name)
+
+    def test_grok_server_tool_names_match_pretooluse(self) -> None:
+        for name in self.GROK.values():
+            self.assertTrue(any_match("PreToolUse", name), msg=name)
+
+    def test_claude_validate_matches_posttooluse(self) -> None:
+        self.assertTrue(any_match("PostToolUse", self.CLAUDE["validate"]))
+
+    def test_grok_validate_matches_posttooluse(self) -> None:
+        self.assertTrue(any_match("PostToolUse", self.GROK["validate"]))
+
+    def test_unrelated_tools_do_not_match(self) -> None:
+        for name in ("run_terminal_command", "use_tool", "forget_node", "n8n-mcp__search_nodes"):
+            self.assertFalse(any_match("PreToolUse", name), msg=name)
+
+
+class EmitTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmpdir = self._tmp.name
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def test_claude_session_id_emits_once(self) -> None:
+        sid = f"claude-{uuid.uuid4()}"
+        payload = {"session_id": sid}
+        first = run_script(EMIT, payload, extra_args=["lifecycle", "load n8n-workflow-patterns"], tmpdir=self.tmpdir)
+        self.assertEqual(first.returncode, 0, first.stderr)
+        self.assertIn("n8n-workflow-patterns", context_text(first.stdout))
+        second = run_script(EMIT, payload, extra_args=["lifecycle", "load n8n-workflow-patterns"], tmpdir=self.tmpdir)
+        self.assertEqual(second.stdout.strip(), "")
+
+    def test_grok_sessionId_emits_once(self) -> None:
+        sid = f"grok-{uuid.uuid4()}"
+        payload = {"sessionId": sid, "hookEventName": "pre_tool_use"}
+        first = run_script(EMIT, payload, extra_args=["lifecycle", "load n8n-workflow-patterns"], tmpdir=self.tmpdir)
+        self.assertEqual(first.returncode, 0, first.stderr)
+        self.assertIn("n8n-workflow-patterns", context_text(first.stdout))
+        second = run_script(EMIT, payload, extra_args=["lifecycle", "load n8n-workflow-patterns"], tmpdir=self.tmpdir)
+        self.assertEqual(second.stdout.strip(), "")
+
+
+class GetNodeTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmpdir = self._tmp.name
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def test_claude_tool_input_set_node(self) -> None:
+        payload = {
+            "session_id": f"claude-set-{uuid.uuid4()}",
+            "tool_input": {"nodeType": "nodes-base.set"},
+        }
+        result = run_script(GET_NODE, payload, tmpdir=self.tmpdir)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        ctx = context_text(result.stdout)
+        self.assertIn("Set node detected", ctx)
+        self.assertIn("n8n-expression-syntax", ctx)
+
+    def test_grok_toolInput_set_node(self) -> None:
+        payload = {
+            "sessionId": f"grok-set-{uuid.uuid4()}",
+            "hookEventName": "pre_tool_use",
+            "toolName": "n8n-mcp__get_node",
+            "toolInput": {"nodeType": "nodes-base.set"},
+        }
+        result = run_script(GET_NODE, payload, tmpdir=self.tmpdir)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        ctx = context_text(result.stdout)
+        self.assertIn("Set node detected", ctx)
+        self.assertIn("n8n-expression-syntax", ctx)
+
+
+class SessionStartTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmpdir = self._tmp.name
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def test_grok_compact_clears_markers_using_sessionId(self) -> None:
+        sid = f"grok-compact-{uuid.uuid4()}"
+        emit = run_script(
+            EMIT,
+            {"sessionId": sid},
+            extra_args=["node-config", "invoke n8n-node-configuration"],
+            tmpdir=self.tmpdir,
+        )
+        self.assertIn("n8n-node-configuration", context_text(emit.stdout))
+
+        start = run_script(
+            SESSION_START,
+            {"sessionId": sid, "source": "compact", "hookEventName": "session_start"},
+            tmpdir=self.tmpdir,
+        )
+        self.assertEqual(start.returncode, 0, start.stderr)
+        self.assertIn("using-n8n-mcp-skills", context_text(start.stdout))
+
+        again = run_script(
+            EMIT,
+            {"sessionId": sid},
+            extra_args=["node-config", "invoke n8n-node-configuration"],
+            tmpdir=self.tmpdir,
+        )
+        self.assertIn("n8n-node-configuration", context_text(again.stdout))
+
+
+class PostValidateTests(unittest.TestCase):
+    def test_grok_toolInput_workflow_nodes(self) -> None:
+        payload = {
+            "sessionId": f"grok-val-{uuid.uuid4()}",
+            "toolName": "n8n-mcp__validate_workflow",
+            "toolInput": {
+                "workflow": {
+                    "nodes": [
+                        {"type": "n8n-nodes-base.set"},
+                        {"type": "n8n-nodes-base.merge"},
+                    ]
+                }
+            },
+        }
+        result = run_script(POST_VALIDATE, payload)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        ctx = context_text(result.stdout)
+        self.assertIn("Set", ctx)
+        self.assertIn("Merge", ctx)
+        self.assertIn("n8n-expression-syntax", ctx)
+        self.assertIn("n8n-node-configuration", ctx)
+
+    def test_claude_tool_input_workflow_nodes_still_work(self) -> None:
+        payload = {
+            "session_id": f"claude-val-{uuid.uuid4()}",
+            "tool_input": {
+                "workflow": {
+                    "nodes": [{"type": "n8n-nodes-base.code"}]
+                }
+            },
+        }
+        result = run_script(POST_VALIDATE, payload)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("n8n-code-javascript", context_text(result.stdout))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/using-n8n-mcp-skills/README.md
+++ b/skills/using-n8n-mcp-skills/README.md
@@ -21,9 +21,9 @@ cross-cutting rules.
 ## Skill Activation
 
 This skill is loaded automatically at session start (via the `SessionStart` hook) when
-the pack is installed as a Claude Code / Codex plugin. It also activates by description
-whenever the user mentions n8n, workflows, nodes, or automation — which makes it work as
-a plain skill on Claude.ai too, where hooks are not available.
+the pack is installed as a Claude Code / Codex / Grok plugin. It also activates by
+description whenever the user mentions n8n, workflows, nodes, or automation — which
+makes it work as a plain skill on Claude.ai too, where hooks are not available.
 
 **Example queries**:
 - "Build me an n8n workflow that …"
@@ -68,7 +68,7 @@ session proceeds normally and the skill still activates by its description.
 ## Version
 
 **Version**: 1.0.0
-**Compatibility**: n8n-mcp MCP server; hooks require the Claude Code / Codex plugin install.
+**Compatibility**: n8n-mcp MCP server; hooks require the Claude Code / Codex / Grok plugin install.
 
 ---
 

--- a/skills/using-n8n-mcp-skills/SKILL.md
+++ b/skills/using-n8n-mcp-skills/SKILL.md
@@ -23,11 +23,10 @@ but breaks in production.
 1. **Invoke the relevant skill before any n8n action** — not just before MCP calls.
    Before writing an expression, configuring a node, designing a workflow, wiring a
    connection, or writing Code, invoke the matching skill. PreToolUse hooks remind you on
-   the highest-impact tool calls, but they exist **only in the Claude Code plugin
-   install**. Everywhere else — Claude.ai skill uploads, and any client that loads this
-   pack as an Agent Plugin (Codex, Cursor, Copilot and the rest) — nothing nudges you and
-   the responsibility is entirely yours. Assume you are un-hooked unless you have seen a
-   hook fire this session.
+   the highest-impact tool calls in the **Claude Code / Codex / Grok plugin install**. On
+   Claude.ai skill uploads, and any client that loads this pack without running the hooks
+   (Cursor, Copilot, and the rest), nothing nudges you and the responsibility is entirely
+   yours. Assume you are un-hooked unless you have seen a hook fire this session.
 2. **Validate AND verify before activating.** Run `validate_workflow` (or
    `n8n_validate_workflow` by id) before you activate, and call `n8n_get_workflow` after
    every create or update to inspect the `connections` object. Validation alone misses


### PR DESCRIPTION
Same class of harness mismatch as #45, but Grok's hook JSON is Claude-shaped rather than Antigravity's root-level schema. Two things never fired on Grok:

- Matchers were `^mcp__.*__get_node$`. Grok advertises MCP calls as `n8n-mcp__get_node` (`server__tool`), not `mcp__n8n-mcp__get_node`.
- Scripts read `.session_id` and `.tool_input`. Grok sends `.sessionId` and `.toolInput`.

This keeps the Claude envelopes working (`mcp__…` names, snake_case keys) and adds Grok's `server__tool` names plus camelCase keys. `python3 hooks/tests/test_harness_compat.py` covers both. `hooks/tests/test_e2e_grok_plugin.py` checks a live Grok install and skips when `grok` is not on PATH.