### PR TITLE
docs: surface the AiAdvisors call-to-action at the top of README

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,7 +3,7 @@
   "description": "Expert skills for building n8n workflows",
   "owner": {
     "name": "Romuald Członkowski",
-    "url": "https://www.aiadvisors.pl/en"
+    "url": "https://aiadvisors.pl/en"
   },
   "plugins": [
     {
@@ -30,7 +30,7 @@
       "version": "1.34.0",
       "author": {
         "name": "Romuald Członkowski",
-        "url": "https://www.aiadvisors.pl/en"
+        "url": "https://aiadvisors.pl/en"
       },
       "category": "automation",
       "keywords": [

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -4,7 +4,7 @@
   "description": "Expert skills for building n8n workflows with n8n-mcp, with a hooks enforcement layer",
   "author": {
     "name": "Romuald Członkowski",
-    "url": "https://www.aiadvisors.pl/en"
+    "url": "https://aiadvisors.pl/en"
   },
   "license": "MIT",
   "keywords": [

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,7 +214,7 @@ Available as:
 
 ## Credits
 
-Conceived by Romuald Członkowski - [www.aiadvisors.pl/en](https://www.aiadvisors.pl/en)
+Conceived by Romuald Członkowski - [aiadvisors.pl/en](https://aiadvisors.pl/en)
 
 Part of the n8n-mcp project.
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 
 [![n8n Skills Introduction](skills.png)](https://youtu.be/e6VvRqmUY2Y?si=6Igply3cadjO6Xx0)
 
+> 💼 **Need it built for you?** Work with [AiAdvisors — n8n automation audits, builds, and operations](https://aiadvisors.pl/en), run by the author of n8n-mcp and n8n-skills.
+
 ---
 
 ## 🎯 What is this?
@@ -360,7 +362,7 @@ MIT License - see [LICENSE](LICENSE) file for details.
 ## 🙏 Credits
 
 **Conceived by Romuald Członkowski**
-- Website: [www.aiadvisors.pl/en](https://www.aiadvisors.pl/en)
+- Website: [aiadvisors.pl/en](https://aiadvisors.pl/en)
 - Part of the [n8n-mcp project](https://github.com/czlonkowski/n8n-mcp)
 
 The hooks enforcement layer adapts patterns from the official [n8n Skills](https://github.com/n8n-io/skills) project (Apache-2.0), retargeted for n8n-mcp and rewritten in our own voice. See [NOTICES](NOTICES).
@@ -390,4 +392,4 @@ The hooks enforcement layer adapts patterns from the official [n8n Skills](https
 
 ## 💼 Need it built for you?
 
-Work with **[AiAdvisors](https://www.aiadvisors.pl/en)** — automation audits, builds, and operations by the team behind n8n-mcp and n8n-skills.
+Work with **[AiAdvisors — n8n automation audits, builds, and operations](https://aiadvisors.pl/en)**, run by the author of n8n-mcp and n8n-skills.

--- a/docs/CODE_NODE_BEST_PRACTICES.md
+++ b/docs/CODE_NODE_BEST_PRACTICES.md
@@ -1201,4 +1201,4 @@ With these patterns, best practices, and real-world insights, you'll create robu
 
 ---
 
-**Conceived by Romuald Członkowski** - [www.aiadvisors.pl/en](https://www.aiadvisors.pl/en)
+**Conceived by Romuald Członkowski** - [aiadvisors.pl/en](https://aiadvisors.pl/en)

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -630,4 +630,4 @@ All contributions must be compatible with MIT License.
 
 ---
 
-Conceived by Romuald Członkowski - [www.aiadvisors.pl/en](https://www.aiadvisors.pl/en)
+Conceived by Romuald Członkowski - [aiadvisors.pl/en](https://aiadvisors.pl/en)

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -351,4 +351,4 @@ cp -r skills/n8n-mcp-tools-expert ~/.claude/skills/
 
 ---
 
-Conceived by Romuald Członkowski - [www.aiadvisors.pl/en](https://www.aiadvisors.pl/en)
+Conceived by Romuald Członkowski - [aiadvisors.pl/en](https://aiadvisors.pl/en)

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -499,4 +499,4 @@ All relevant skills will activate automatically.
 
 ---
 
-Conceived by Romuald Członkowski - [www.aiadvisors.pl/en](https://www.aiadvisors.pl/en)
+Conceived by Romuald Członkowski - [aiadvisors.pl/en](https://aiadvisors.pl/en)

--- a/plugin.json
+++ b/plugin.json
@@ -5,7 +5,7 @@
   "description": "Expert skills for building n8n workflows with the n8n-mcp MCP server",
   "author": {
     "name": "Romuald Członkowski",
-    "url": "https://www.aiadvisors.pl/en"
+    "url": "https://aiadvisors.pl/en"
   },
   "homepage": "https://github.com/czlonkowski/n8n-skills",
   "repository": "https://github.com/czlonkowski/n8n-skills",

--- a/skills/n8n-code-javascript/README.md
+++ b/skills/n8n-code-javascript/README.md
@@ -345,6 +345,6 @@ Each evaluation tests skill activation, correct guidance, and reference to appro
 
 ## Author
 
-Conceived by Romuald Członkowski - [www.aiadvisors.pl/en](https://www.aiadvisors.pl/en)
+Conceived by Romuald Członkowski - [aiadvisors.pl/en](https://aiadvisors.pl/en)
 
 Part of the n8n-skills collection.

--- a/skills/n8n-code-python/README.md
+++ b/skills/n8n-code-python/README.md
@@ -378,7 +378,7 @@ Use JavaScript instead when:
 Part of the n8n-skills project.
 
 **Conceived by Romuald Członkowski**
-- Website: [www.aiadvisors.pl/en](https://www.aiadvisors.pl/en)
+- Website: [aiadvisors.pl/en](https://aiadvisors.pl/en)
 - Part of [n8n-mcp project](https://github.com/czlonkowski/n8n-mcp)
 
 ---

--- a/skills/n8n-expression-syntax/README.md
+++ b/skills/n8n-expression-syntax/README.md
@@ -90,4 +90,4 @@ Teaches correct n8n expression syntax ({{ }} patterns) and fixes common mistakes
 ---
 
 **Part of**: n8n-skills repository
-**Conceived by**: Romuald Członkowski - [www.aiadvisors.pl/en](https://www.aiadvisors.pl/en)
+**Conceived by**: Romuald Członkowski - [aiadvisors.pl/en](https://aiadvisors.pl/en)

--- a/skills/n8n-mcp-tools-expert/README.md
+++ b/skills/n8n-mcp-tools-expert/README.md
@@ -96,4 +96,4 @@ Teaches how to use n8n-mcp MCP server tools correctly for efficient workflow bui
 ---
 
 **Part of**: n8n-skills repository
-**Conceived by**: Romuald Członkowski - [www.aiadvisors.pl/en](https://www.aiadvisors.pl/en)
+**Conceived by**: Romuald Członkowski - [aiadvisors.pl/en](https://aiadvisors.pl/en)

--- a/skills/n8n-node-configuration/README.md
+++ b/skills/n8n-node-configuration/README.md
@@ -359,6 +359,6 @@ get_node({nodeType: "nodes-base.slack"});
 
 ## Author
 
-Conceived by Romuald Członkowski - [www.aiadvisors.pl/en](https://www.aiadvisors.pl/en)
+Conceived by Romuald Członkowski - [aiadvisors.pl/en](https://aiadvisors.pl/en)
 
 Part of the n8n-skills meta-skill collection.

--- a/skills/n8n-validation-expert/README.md
+++ b/skills/n8n-validation-expert/README.md
@@ -285,6 +285,6 @@ if (preview.fixCount > 0) {
 
 ## Author
 
-Conceived by Romuald Członkowski - [www.aiadvisors.pl/en](https://www.aiadvisors.pl/en)
+Conceived by Romuald Członkowski - [aiadvisors.pl/en](https://aiadvisors.pl/en)
 
 Part of the n8n-skills meta-skill collection.

--- a/skills/n8n-workflow-patterns/README.md
+++ b/skills/n8n-workflow-patterns/README.md
@@ -248,4 +248,4 @@ Use `search_templates` to find examples for your use case!
 ---
 
 **Part of**: n8n-skills repository
-**Conceived by**: Romuald Członkowski - [www.aiadvisors.pl/en](https://www.aiadvisors.pl/en)
+**Conceived by**: Romuald Członkowski - [aiadvisors.pl/en](https://aiadvisors.pl/en)


### PR DESCRIPTION
## Intent

Same motivation as czlonkowski/n8n-mcp: github.com is the top converting referrer for aiadvisors.pl, but the call-to-action lives two lines from the bottom of the README. This moves it to the top and normalises every link.

## Changes

- README: add the "Need it built for you?" line right after the intro video; reword the bottom one with a descriptive anchor; Credits link normalised
- CLAUDE.md, docs/*.md, skills/*/README.md, plugin.json, .claude-plugin/*.json: every `www.aiadvisors.pl/en` link becomes `https://aiadvisors.pl/en` (skips the www redirect, keeps the referrer)

Documentation and manifests only, no skill content changes.

## Verification

- `git grep www.aiadvisors` returns nothing outside `dist/`
- Links resolve with a single 200

Conceived by Romuald Członkowski - https://aiadvisors.pl/en

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R194ePthLghLRgnMMS9dui